### PR TITLE
Make the TLDR instructions more complete

### DIFF
--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -3,7 +3,7 @@
 As a tutorial, we will go through and explain the folder and files structure used to generate this website. You could use this as a template for your project's documentation.
 
 !!! tip
-    In general, you can copy the `docs` folder and the `.github/Documenter.yml` action file to your repo, and be pretty much good to go and edit docs as usual! 
+    In general, you can copy the `docs` folder and the `.github/Documenter.yml` action file from https://github.com/LuxDL/DocumenterVitepress.jl to your repo, and be pretty much good to go and edit docs as usual! 
     
     Just remember to edit the sidebar in `docs/src/.vitepress/config.mts`.
 


### PR DESCRIPTION
If I want to jump straight to seeing functionally built docs without writing any content of my own, then I also probably want a direct link to the source to copy rather than having to find it (even if happens to be only one click away at the top right of the screen).