### PR TITLE
ContentsNode Heading Handling Patch

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DocumenterVitepress"
 uuid = "4710194d-e776-4893-9690-8d956a29c365"
 authors = ["Lazaro Alonso <lazarus.alon@gmail.com>", "Anshul Singhvi <as6208@columbia.edu>"]
-version = "0.0.1"
+version = "0.0.2"
 
 [deps]
 ANSIColoredPrinters = "a4c015fc-c6ff-483c-b24f-f7ea428134e9"

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -152,8 +152,8 @@ function render(io::IO, ::MIME"text/plain", node::Documenter.MarkdownAST.Node, c
         path = mdext(path)
         header = anchor.object
         url = string(path, Documenter.anchor_fragment(anchor))
-        link = Markdown.Link(header.text, url)
-        level = Documenter.header_level(header)
+        link = Markdown.Link(anchor.id, url)
+        level = anchor.order
         print(io, "    "^(level - 1), "- ")
         linkfix = ".md#"
         println(io, replace(Markdown.plaininline(link), linkfix => "#"))


### PR DESCRIPTION
Showed up in https://buildkite.com/julialang/lux-dot-jl/builds/958#018dd76c-0101-45c5-957f-2bf7559c9cb2/2039-3273.

Someone needs to check if I am using the correct fields, but from the dump, this made sense.