### PR TITLE
Fix code block rendering

### DIFF
--- a/docs/src/code_example.md
+++ b/docs/src/code_example.md
@@ -73,3 +73,11 @@ Markdown.parse("""
     The documentation is also available in PDF format: [$file]($url).
 """)
 ```
+
+## REPL example
+
+```@repl
+a = 1
+b = 2
+a + b
+```

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -655,6 +655,16 @@ function render(io::IO, mime::MIME"text/plain", node::Documenter.MarkdownAST.Nod
 end
 # Code blocks
 function render(io::IO, mime::MIME"text/plain", node::Documenter.MarkdownAST.Node, code::MarkdownAST.CodeBlock, page, doc; kwargs...)
+    Main.@infiltrate
+    if startswith(code.info, "@")
+        @warn """
+        DocumenterVitepress: un-expanded `$(code.info)` block encountered on page $(page.source).
+        The first few lines of code in this node are:
+        ```
+        $(join(Iterators.take(split(code.code, '\n'), 6), "\n")
+        ```
+        """
+    end
     info = intelligent_language(code.info)
     render(io, mime, node, Markdown.Code(info, code.code), page, doc; kwargs...)
 end

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -655,7 +655,6 @@ function render(io::IO, mime::MIME"text/plain", node::Documenter.MarkdownAST.Nod
 end
 # Code blocks
 function render(io::IO, mime::MIME"text/plain", node::Documenter.MarkdownAST.Node, code::MarkdownAST.CodeBlock, page, doc; kwargs...)
-    Main.@infiltrate
     if startswith(code.info, "@")
         @warn """
         DocumenterVitepress: un-expanded `$(code.info)` block encountered on page $(page.source).

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -661,7 +661,7 @@ function render(io::IO, mime::MIME"text/plain", node::Documenter.MarkdownAST.Nod
         DocumenterVitepress: un-expanded `$(code.info)` block encountered on page $(page.source).
         The first few lines of code in this node are:
         ```
-        $(join(Iterators.take(split(code.code, '\n'), 6), "\n")
+        $(join(Iterators.take(split(code.code, '\n'), 6), "\n"))
         ```
         """
     end

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -405,7 +405,7 @@ function join_multiblock(node::Documenter.MarkdownAST.Node)
                 end
             end
         end
-        return [Markdown.Code(mcb.language, String(take!(io)))]
+        return [Markdown.Code(intelligent_language(mcb.language), String(take!(io)))]
     end
 end
 

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -352,10 +352,12 @@ function render(io::IO, mime::MIME"text/plain", node::Documenter.MarkdownAST.Nod
 end
 
 function intelligent_language(lang::String)
-    if lang == "ansi"
-        "julia /julia>/"
-    elseif lang == "documenter-ansi"
+    if lang == "documenter-ansi"
         "ansi"
+    elseif lang ∈ ("ansi", "julia-repl", "@doctest", "@repl")
+        "julia /julia>/"
+    elseif lang ∈ ("@example",)
+        "julia"
     else
         lang
     end
@@ -653,12 +655,7 @@ function render(io::IO, mime::MIME"text/plain", node::Documenter.MarkdownAST.Nod
 end
 # Code blocks
 function render(io::IO, mime::MIME"text/plain", node::Documenter.MarkdownAST.Node, code::MarkdownAST.CodeBlock, page, doc; kwargs...)
-    info = code.info
-    if info ∈ ("julia-repl", "@doctest", "@repl")
-        info = "julia /julia>/"
-    elseif info ∈ ("@example", )
-        info = "julia"
-    end
+    info = intelligent_language(code.info)
     render(io, mime, node, Markdown.Code(info, code.code), page, doc; kwargs...)
 end
 # Inline code

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -361,7 +361,7 @@ function intelligent_language(lang::String)
     end
 end
 
-function join_multiblock(mcb::Documenter.MultiCodeBlock)
+function join_multiblock(node::Documenter.MarkdownAST.Node)
     if mcb.language == "ansi"
         # Return a vector of Markdown code blocks
         # where each block is a single line of the output or input.
@@ -369,9 +369,9 @@ function join_multiblock(mcb::Documenter.MultiCodeBlock)
         # and whenever the language changes, we
         # start a new code block and push the old one to the array!
         codes = Markdown.Code[]
-        current_language = first(mcb.content).language
+        current_language = first(node.children).language
         current_string = ""
-        for thing in mcb.content
+        for thing in (n.element::MarkdownAST.CodeBlock for n in node.children)
             # reset the buffer and push the old code block
             if thing.language != current_language
                 # Remove this if statement if you want to 
@@ -394,7 +394,7 @@ function join_multiblock(mcb::Documenter.MultiCodeBlock)
     end
     # else
         io = IOBuffer()
-        for (i, thing) in enumerate(mcb.content)
+        for (i, thing) in enumerate((n.element::MarkdownAST.CodeBlock for n in node.children))
             print(io, thing.code)
             if i != length(mcb.content)
                 println(io)
@@ -403,12 +403,12 @@ function join_multiblock(mcb::Documenter.MultiCodeBlock)
                 end
             end
         end
-        return Markdown.Code(mcb.language, String(take!(io)))
+        return [Markdown.Code(mcb.language, String(take!(io)))]
     # end
 end
 
 function render(io::IO, mime::MIME"text/plain", node::Documenter.MarkdownAST.Node, mcb::Documenter.MultiCodeBlock, page, doc; kwargs...)
-    return render(io, mime, node, join_multiblock(mcb), page, doc; kwargs...)
+    return render(io, mime, node, join_multiblock(node), page, doc; kwargs...)
 end
 
 


### PR DESCRIPTION
- Fix MultiCodeBlock rendering and get correct `@repl` output
- Unify intelligent language framework
- Warn properly when an `@*` code block is detected by the renderer

Fixes #102 