### PR TITLE
Build vitepress directly without relying on package.json in writer

### DIFF
--- a/src/writer.jl
+++ b/src/writer.jl
@@ -184,7 +184,7 @@ function render(doc::Documenter.Document, settings::MarkdownVitepress=MarkdownVi
                     end
                     run(`$(npm) install`)
                 end
-                run(`$(npm) run docs:build`)
+                run(`$(npm) run env -- vitepress build $(joinpath(builddir, settings.md_output_path))`)
             end
         catch e
             rethrow(e)


### PR DESCRIPTION
@lazarusA this should fix the Julia build