### PR TITLE
fix escaping characters

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -38,7 +38,7 @@ features:
 ---
 ```
 
-
+```@raw html
 <p style="margin-bottom:2cm"></p>
 
 <div class="vp-doc" style="width:80%; margin:auto">
@@ -58,3 +58,4 @@ Just remember to edit the navbar in `docs/src/.vitepress/config.mts`, if you wan
 To install a logo or favicon, you can put `logo.png` and `favicon.ico` in `docs/src/assets`, and they will be automatically detected.
 
 </div>
+```

--- a/docs/src/markdown-examples.md
+++ b/docs/src/markdown-examples.md
@@ -260,7 +260,11 @@ sshflags=`-i <keyfile>`
 ```
 but within inline text it does not. Ideas for the escaping sequence?
 
-`sshflags=&#96;-i <keyfile>&#96;`
+This is the expected sequence by vitepress:
+
+````
+<code> sshflags= `` `-i <keyfile> ` `` </code>
+````
 
 
 ## More

--- a/docs/src/markdown-examples.md
+++ b/docs/src/markdown-examples.md
@@ -234,6 +234,34 @@ Don't type anything after the last double dollar sign, and make sure there are n
 
 Here is the link for the paper of Babushka[^1]
 
+## Escaping characters
+
+The following example:
+
+```md
+< `less` and `greater` > than, and the backtick \`.
+```
+outputs:
+
+< `less` and `greater` > than, and the backtick \`.
+
+And also, this <was> an <issue> before.
+
+Let's see if this one works:
+
+````
+```
+sshflags=`-i <keyfile>`
+```
+````
+it does,
+```
+sshflags=`-i <keyfile>`
+```
+but within inline text it does not. Ideas for the escaping sequence?
+
+`sshflags=&#96;-i <keyfile>&#96;`
+
 
 ## More
 

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -1,4 +1,5 @@
 import Documenter: Documenter, Builder, Expanders, MarkdownAST
+import Documenter.DOM: escapehtml
 
 import ANSIColoredPrinters
 using Base64: base64decode, base64encode
@@ -617,7 +618,7 @@ function render(io::IO, mime::MIME"text/plain", node::Documenter.MarkdownAST.Nod
 end
 # Plain text
 function render(io::IO, mime::MIME"text/plain", node::Documenter.MarkdownAST.Node, text::MarkdownAST.Text, page, doc; kwargs...)
-    print(io, text.text)
+    print(io, escapehtml(text.text))
 end
 # Heading
 function render(io::IO, mime::MIME"text/plain", node::Documenter.MarkdownAST.Node, text::MarkdownAST.Heading, page, doc; kwargs...)


### PR DESCRIPTION
fixes special characters when in text. it should fix https://github.com/LuxDL/DocumenterVitepress.jl/issues/101 (only the original issue). The other ones, should be addressed somewhere else. 