### PR TITLE
Improve the docs for MarkdownVitepress

### DIFF
--- a/src/writer.jl
+++ b/src/writer.jl
@@ -37,7 +37,8 @@ Base.@kwdef struct MarkdownVitepress <: Documenter.Writer
     devurl::String = "dev"
     """
     The URL of the repository to which the documentation will be deployed.  
-    This **must** be the full URL, **including `https://`**, like `https://rafaqz.github.io/Rasters.jl` or `https://geo.makie.jl`."
+    This **must** be the full URL, **including `https://`**, like `https://rafaqz.github.io/Rasters.jl` or `https://geo.makie.jl/`.
+    """
     deploy_url::Union{String, Nothing} = nothing
     "A description of the website as a String."
     description::String = "Documentation for $(splitdir(repo)[end])"

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -29,14 +29,16 @@ The `repo` kwarg is used to set the edit link for the documentation.
 The `devbranch` and `devurl` kwargs are used to set the path of the static site, which Vitepress expects in advance.
 """
 Base.@kwdef struct MarkdownVitepress <: Documenter.Writer
-    "*Required*: The URL of the repository to which the documentation will be deployed.  This must be the full URL, like `rafaqz.github.io/Rasters.jl` or `geo.makie.jl`."
-    deploy_url::Union{String, Nothing} = nothing
     "*Required*: The full URL of the repository to which the documentation will be deployed."
     repo::String
-    "*Required*: The name of the development branch, like `master` or `main`."
+    "The name of the development branch, like `master` or `main`."
     devbranch::String = Documenter.git_remote_head_branch("MarkdownVitepress(devbranch = ...)", Documenter.currentdir())
-    "*Required*: The URL path to the development site, like `dev` or `dev-branch`."
+    "The URL path to the development site, like `dev` or `dev-branch`."
     devurl::String = "dev"
+    """
+    The URL of the repository to which the documentation will be deployed.  
+    This **must** be the full URL, **including `https://`**, like `https://rafaqz.github.io/Rasters.jl` or `https://geo.makie.jl`."
+    deploy_url::Union{String, Nothing} = nothing
     "A description of the website as a String."
     description::String = "Documentation for $(splitdir(repo)[end])"
     """Determines whether to build the Vitepress site or only emit markdown files.  Defaults to `true`, i.e., building the full Vitepress site."""


### PR DESCRIPTION
Hopefully this discourages people from using incorrect `deploy_url`s.