### PR TITLE
Make things work with LiveServer

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DocumenterVitepress"
 uuid = "4710194d-e776-4893-9690-8d956a29c365"
 authors = ["Lazaro Alonso <lazarus.alon@gmail.com>", "Anshul Singhvi <as6208@columbia.edu>"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 ANSIColoredPrinters = "a4c015fc-c6ff-483c-b24f-f7ea428134e9"

--- a/src/vitepress_config.jl
+++ b/src/vitepress_config.jl
@@ -31,7 +31,7 @@ function modify_config_file(doc, settings, deploy_decision)
     builddir = isabspath(doc.user.build) ? doc.user.build : joinpath(doc.user.root, doc.user.build)
     sourcedir = isabspath(doc.user.source) ? doc.user.source : joinpath(doc.user.root, doc.user.source)
     source_vitepress_dir = joinpath(sourcedir, ".vitepress")
-    build_vitepress_dir = joinpath(builddir, settings.md_output_path, ".vitepress")
+    build_vitepress_dir = normpath(joinpath(builddir, settings.md_output_path, ".vitepress"))
     template_vitepress_dir = joinpath(dirname(@__DIR__), "template", "src", ".vitepress")
     mkpath(joinpath(builddir, settings.md_output_path, ".vitepress", "theme"))
     vitepress_config_file = joinpath(sourcedir, ".vitepress", "config.mts") # We check the source dir here because `clean=false` will persist the old, non-generated file in the build dir, and we need to overwrite it.

--- a/src/vitepress_config.jl
+++ b/src/vitepress_config.jl
@@ -128,7 +128,8 @@ function modify_config_file(doc, settings, deploy_decision)
 
     new_config = replace(config, replacers...)
     write(vitepress_config_file, new_config)
-
+    yield()
+    touch(vitepress_config_file)
 
     #
 

--- a/src/vitepress_interface.jl
+++ b/src/vitepress_interface.jl
@@ -13,7 +13,7 @@ Work is in progress to let the user pass the config object to fix this.
     This does **NOT** run `makedocs` - you have to do that yourself!
     Think of it as the second stage of `LiveServer.jl` for DocumenterVitepress specifically.
 """
-dev_docs(builddir::String; md_output_path = ".documenter") = run_vitepress_command(builddir, "dev"; md_output_path)
+dev_docs(builddir::String; md_output_path = ".documenter") = run_vitepress_command(builddir, "dev"; md_output_path, kwargs = `--force`)
 
 """
     build_docs(builddir::String; md_output_path = ".documenter")
@@ -25,7 +25,7 @@ If passing a String, pass the path to the `builddir`, i.e., `\$packagepath/docs/
 build_docs(builddir::String; md_output_path = ".documenter") = run_vitepress_command(builddir, "build"; md_output_path)
 
 
-function run_vitepress_command(builddir::String, command::String; md_output_path = ".documenter")
+function run_vitepress_command(builddir::String, command::String; md_output_path = ".documenter", kwargs = ``)
     @assert ispath(builddir)
     builddir = abspath(builddir)
     @info "DocumenterVitepress: running `vitepress $command`."
@@ -50,7 +50,7 @@ function run_vitepress_command(builddir::String, command::String; md_output_path
                     end
                     run(`$(npm) install`)
                 end
-                run(`$(npm) run env -- vitepress $command $(joinpath(splitpath(builddir)[end], md_output_path))`)
+                run(`$(npm) run env -- vitepress $command $(kwargs) $(joinpath(splitpath(builddir)[end], md_output_path))`)
             end
         end
     catch e

--- a/src/vitepress_interface.jl
+++ b/src/vitepress_interface.jl
@@ -50,7 +50,7 @@ function run_vitepress_command(builddir::String, command::String; md_output_path
                     end
                     run(`$(npm) install`)
                 end
-                run(`$(npm) run env -- vitepress $command $(kwargs) $(joinpath(splitpath(builddir)[end], md_output_path))`)
+                run(`$(npm) run env -- vitepress $command $(joinpath(splitpath(builddir)[end], md_output_path)) $(kwargs)`)
             end
         end
     catch e

--- a/src/vitepress_interface.jl
+++ b/src/vitepress_interface.jl
@@ -50,7 +50,7 @@ function run_vitepress_command(builddir::String, command::String; md_output_path
                     end
                     run(`$(npm) install`)
                 end
-                run(`$(npm) run env -- vitepress $command $(joinpath(splitpath(builddir)[end], md_output_path)) $(kwargs)`)
+                run(`$(npm) run env -- vitepress $command $(normpath(joinpath(splitpath(builddir)[end], md_output_path))) $(kwargs)`)
             end
         end
     catch e

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -110,11 +110,17 @@ function render(doc::Documenter.Document, settings::MarkdownVitepress=MarkdownVi
     # Then, we create a path to the folder where we will emit the markdown,
     mkpath(joinpath(builddir, settings.md_output_path))
     # and copy the previous build files to the new location.
-    for file_or_dir in current_build_files_or_dirs
-        src = joinpath(builddir, file_or_dir)
-        dst = joinpath(builddir, settings.md_output_path, file_or_dir)
-        cp(src, dst)
-        rm(src; recursive = true)
+    if settings.md_output_path != "."
+        for file_or_dir in current_build_files_or_dirs
+            src = joinpath(builddir, file_or_dir)
+            dst = joinpath(builddir, settings.md_output_path, file_or_dir)
+            if src != dst
+                cp(src, dst; force = true)
+                rm(src; recursive = true)
+            else
+                println(src, dest)
+            end
+        end
     end
     # Documenter.jl wants assets in `assets/`, but Vitepress likes them in `public/`,
     # so we rename the folder.
@@ -126,13 +132,19 @@ function render(doc::Documenter.Document, settings::MarkdownVitepress=MarkdownVi
         if any(logo_files)
             for file in files[logo_files]
                 file_relpath = relpath(file, joinpath(builddir, settings.md_output_path, "assets"))
-                cp(file, joinpath(builddir, settings.md_output_path, "public", file_relpath))
+                file_destpath = joinpath(builddir, settings.md_output_path, "public", file_relpath)
+                if normpath(file) != normpath(file_destpath)
+                    cp(file, file_destpath; force = true)
+                end
             end
         end 
         if any(favicon_files)
             for file in files[favicon_files]
                 file_relpath = relpath(file, joinpath(builddir, settings.md_output_path, "assets"))
-                cp(file, joinpath(builddir, settings.md_output_path, "public", file_relpath))
+                file_destpath = joinpath(builddir, settings.md_output_path, "public", file_relpath)
+                if normpath(file) != normpath(file_destpath)
+                    cp(file, file_destpath; force = true)
+                end
             end
         end
     end


### PR DESCRIPTION
Set `clean=false` in makedocs and `md_output_path="."` in MarkdownVitepress to do this.

Changes:
- If md_output_path is ".", skip copying
- Allow kwargs in run_vitepress_command
- dev_docs has `--force`
- Check that files don't have the same path (this can be done better via `Base.samefile`