### PR TITLE
feat: minor improvements to the new docstring blocks

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DocumenterVitepress"
 uuid = "4710194d-e776-4893-9690-8d956a29c365"
 authors = ["Lazaro Alonso <lazarus.alon@gmail.com>", "Anshul Singhvi <as6208@columbia.edu>"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 ANSIColoredPrinters = "a4c015fc-c6ff-483c-b24f-f7ea428134e9"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -53,6 +53,7 @@ makedocs(;
         ],
         "Developers' documentation" => [
             "The rendering process" => "render_pipeline.md",
+            "Internal API" => "internal_api.md",
         ],
         "api.md",
     ],

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -5,8 +5,11 @@ outline: deep
 ```
 
 ## Public API
+
 ```@meta
-DocTestSetup= quote
+CollapsedDocStrings = true
+
+DocTestSetup = quote
 using DocumenterVitepress
 end
 ```

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -7,8 +7,6 @@ outline: deep
 ## Public API
 
 ```@meta
-CollapsedDocStrings = true
-
 DocTestSetup = quote
 using DocumenterVitepress
 end

--- a/docs/src/code_example.md
+++ b/docs/src/code_example.md
@@ -207,4 +207,12 @@ Supported meta tags:
   - `CollapsedDocStrings`: works similar to Documenter.jl. If provided, the docstrings in
     that page will be collapsed by default. Defaults to `false`. See the
     [Internal API](@ref internal_api) page for how the docstrings are displayed when this
-    is set to `true`.
+    is set to `true`. Example usage:
+
+**Input**
+
+````
+```@meta
+CollapsedDocStrings = true
+```
+````

--- a/docs/src/code_example.md
+++ b/docs/src/code_example.md
@@ -199,3 +199,12 @@ julia> 1 + 1
 2
 
 ```
+
+## @meta
+
+Supported meta tags:
+
+  - `CollapsedDocStrings`: works similar to Documenter.jl. If provided, the docstrings in
+    that page will be collapsed by default. Defaults to `false`. See the
+    [Internal API](@ref internal_api) page for how the docstrings are displayed when this
+    is set to `true`.

--- a/docs/src/internal_api.md
+++ b/docs/src/internal_api.md
@@ -1,0 +1,22 @@
+```@raw html
+---
+outline: deep
+---
+```
+
+## [Internal API](@id internal_api)
+
+These functions are not part of the public API, and are subject to change without notice.
+
+```@meta
+CollapsedDocStrings = true
+
+DocTestSetup = quote
+using DocumenterVitepress
+end
+```
+
+```@autodocs
+Modules = [DocumenterVitepress]
+Public = false
+```

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -313,10 +313,11 @@ end
 
 function render(io::IO, mime::MIME"text/plain", node::Documenter.MarkdownAST.Node, docs::Documenter.DocsNode, page, doc; kwargs...)
     # @infiltrate
+    open_txt = get(page.globals.meta, :CollapsedDocStrings, false) ? "" : "open"
     anchor_id = Documenter.anchor_label(docs.anchor)
     # Docstring header based on the name of the binding and it's category.
     _badge_text = """<Badge type="info" class="jlObjectType jl$(Documenter.doccat(docs.object))" text="$(Documenter.doccat(docs.object))" />"""
-    print(io ,"""<details class='jldocstring custom-block' open>
+    print(io ,"""<details class='jldocstring custom-block' $(open_txt)>
     <summary><a id='$(anchor_id)' href='#$(anchor_id)'><span class="jlbinding">$(docs.object.binding)</span></a> $(_badge_text)</summary>\n
     """)
     # Body. May contain several concatenated docstrings.

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -317,7 +317,7 @@ function render(io::IO, mime::MIME"text/plain", node::Documenter.MarkdownAST.Nod
     # Docstring header based on the name of the binding and it's category.
     _badge_text = """<Badge type="info" class="jlObjectType jl$(Documenter.doccat(docs.object))" text="$(Documenter.doccat(docs.object))" />"""
     print(io ,"""<details class='jldocstring custom-block' open>
-    <summary><a id='$(anchor_id)' href='#$(anchor_id)'>#</a> <span class="jlbinding">$(docs.object.binding)</span> $(_badge_text)</summary>\n
+    <summary><a id='$(anchor_id)' href='#$(anchor_id)'><span class="jlbinding">$(docs.object.binding)</span></a> $(_badge_text)</summary>\n
     """)
     # Body. May contain several concatenated docstrings.
     renderdoc(io, mime, node, page, doc; kwargs...)


### PR DESCRIPTION
- [x] Makes the docstrings headers similar to how Documenter.jl renders them (without the `#` and makes the name clickable for link)
- [x] adds support for `CollapsedDocStrings` meta. fixes #180 