### PR TITLE
Fix nested markdown list

### DIFF
--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -27,13 +27,13 @@ Here are the tweaks to add:
 
 2. Within the `MarkdownVitepress` configuration of your `make.jl` file, pass the following two key word arguments and their values:
 
-  i. `md_output_path = "."`
+   i. `md_output_path = "."`
 
-  ii. `build_vitepress = false`
+   ii. `build_vitepress = false`
 
 3. Within the `makedocs` command within your `make.jl` file, pass the following key word argument:
 
-  i. `clean = false`
+   i. `clean = false`
 
 Then, to preview changes live, open two separate Julia instances both within the `docs` folder and activate the `docs` environment in both sessions.
 Within one session run `using LiveServer; servedocs(foldername="/path/to/your/docs/folder")` (this could be something like `servedocs(foldername="docs/")` or `servedocs(foldername=pwd())`).


### PR DESCRIPTION
Indent of nested list didn't match start of content (i.e., the part after `2. ...`) so the list was fragmented