### PR TITLE
copy components from template

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DocumenterVitepress"
 uuid = "4710194d-e776-4893-9690-8d956a29c365"
 authors = ["Lazaro Alonso <lazarus.alon@gmail.com>", "Anshul Singhvi <as6208@columbia.edu>"]
-version = "0.1.5"
+version = "0.1.6"
 
 [deps]
 ANSIColoredPrinters = "a4c015fc-c6ff-483c-b24f-f7ea428134e9"

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -143,24 +143,28 @@ function render(doc::Documenter.Document, settings::MarkdownVitepress=MarkdownVi
         end
     end
     # copy vue components
-    source_components = joinpath(dirname(@__DIR__), "template/components")
+    source_components = joinpath(dirname(@__DIR__), "template/src/components")
     destination_dir = joinpath(builddir, settings.md_output_path, "components")
     # Ensure the destination directory exists
     mkpath(destination_dir)
     for item in readdir(source_components)
         src = joinpath(source_components, item)
         dest = joinpath(destination_dir, item)
-        if !exists(dest)  # Check if the destination file or directory already exists
-            if isdir(src)
-                cp(src, dest)  # Copy directories recursively
-            else
-                cp(src, dest) # Copy individual files
+        if !isfile(dest) && !isdir(dest)
+            try
+                if isdir(src)
+                    cp(src, dest; force=true)
+                else
+                    cp(src, dest; force=true)
+                end
+                println("Copied: $dest")
+            catch e
+                println("Error copying $src to $dest: $e")
             end
         else
             println("Skipping: $dest (already exists)")
         end
     end
-
     # Documenter.jl wants assets in `assets/`, but Vitepress likes them in `public/`,
     # so we rename the folder.
     if isdir(joinpath(sourcedir, "assets")) && !isdir(joinpath(sourcedir, "public"))

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -142,6 +142,24 @@ function render(doc::Documenter.Document, settings::MarkdownVitepress=MarkdownVi
             end
         end
     end
+    # copy vue components
+    source_components = joinpath(dirname(@__DIR__), "template/components")
+    destination_dir = joinpath(builddir, settings.md_output_path, "components")
+    # Ensure the destination directory exists
+    mkpath(destination_dir)
+    for item in readdir(source_components)
+        src = joinpath(source_components, item)
+        dest = joinpath(destination_dir, item)
+        if !exists(dest)  # Check if the destination file or directory already exists
+            if isdir(src)
+                cp(src, dest)  # Copy directories recursively
+            else
+                cp(src, dest) # Copy individual files
+            end
+        else
+            println("Skipping: $dest (already exists)")
+        end
+    end
 
     # Documenter.jl wants assets in `assets/`, but Vitepress likes them in `public/`,
     # so we rename the folder.


### PR DESCRIPTION
closes https://github.com/LuxDL/DocumenterVitepress.jl/issues/203

also, if you have a `package.json` file make sure to have `vitepress 1.5.0`.  If you don't have your own, the one from the `template` should work. 