### PR TITLE
Fix the issue of infinite .documenter directories

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -24,7 +24,6 @@ bib = CitationBibliography(
     style=:numeric  # default
 )
 # dev local
-try run(`pkill -f vitepress`) catch end # [!code error]
 
 makedocs(; 
     sitename = "DocumenterVitepress", 

--- a/docs/src/documenter_to_vitepress_docs_example.md
+++ b/docs/src/documenter_to_vitepress_docs_example.md
@@ -55,10 +55,6 @@ Then the very first step here is to update the `make.jl` file to follow the Docu
 
    DocMeta.setdocmeta!(Example, :DocTestSetup, :(using Example); recursive=true)
 
-    # you might need to stop the Vitepress server if it's running before
-    # updating or creating new files
-    try run(`pkill -f vitepress`) catch end # [!code error]
-
    makedocs(;
        modules = [Example],
        repo = Remotes.GitHub("ExampleOrg", "Example.jl"),
@@ -85,6 +81,16 @@ Then the very first step here is to update the `make.jl` file to follow the Docu
    ```
 
    :::
+
+::: details stop any vitepress session
+
+```julia
+# you might need to stop the Vitepress server if it's running before
+# updating or creating new files
+try run(`pkill -f vitepress`) catch end # [!code error]
+```
+
+:::
 
 2. Next, to build new docs from docs/src,
    ```sh

--- a/docs/src/get_started.md
+++ b/docs/src/get_started.md
@@ -3,18 +3,26 @@
 ## Simple method
 
 You can simply add `using DocumenterVitepress` to your `make.jl` file, and replace `format = HTML(...)` in `makedocs` with:
-```julia
-# you might need to stop the Vitepress server if it's running before
-# updating or creating new files
-try run(`pkill -f vitepress`) catch end # [!code error]
 
+```julia
 makedocs(...,
     format = MarkdownVitepress(
         repo = "<url_to_your_repo>",
     )
 )
 ```
+
 and that should be it!
+
+::: details stop any vitepress session
+
+```julia
+# you might need to stop the Vitepress server if it's running before
+# updating or creating new files
+try run(`pkill -f vitepress`) catch end # [!code error]
+```
+
+:::
 
 The section [Advanced method](@ref) describes how to get more control over your Vitepress build.
 

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -132,8 +132,13 @@ function render(doc::Documenter.Document, settings::MarkdownVitepress=MarkdownVi
     # and copy the previous build files to the new location.
     if settings.md_output_path != "."
         for file_or_dir in current_build_files_or_dirs
+            
             src = joinpath(builddir, file_or_dir)
             dst = joinpath(builddir, settings.md_output_path, file_or_dir)
+
+            if src == joinpath(builddir, settings.md_output_path)
+                continue
+            end
             if src != dst
                 cp(src, dst; force = true)
                 rm(src; recursive = true)


### PR DESCRIPTION
when editing in a continuous flow


Sometimes when using LiveServer + DocumenterVitepress, an error message comes up with a very large number of `.documenter` directories.  This PR special cases those so we skip that, and don't recursively end up copying things over time.