### PR TITLE
Remove special characters from link slugs

### DIFF
--- a/docs/src/markdown-examples.md
+++ b/docs/src/markdown-examples.md
@@ -524,6 +524,9 @@ This is the expected sequence by vitepress:
 <code> sshflags= `` `-i <keyfile> ` `` </code>
 ````
 
+## [Heading with a link](https://github.com/LuxDL/DocumenterVitepress.jl) and *bold* font
+
+This was previously breaking due to special markdown characters in the slug.
 
 ## More
 

--- a/docs/src/markdown-examples.md
+++ b/docs/src/markdown-examples.md
@@ -524,7 +524,7 @@ This is the expected sequence by vitepress:
 <code> sshflags= `` `-i <keyfile> ` `` </code>
 ````
 
-## [Heading with a link](https://github.com/LuxDL/DocumenterVitepress.jl) and *bold* font
+## [Heading with a link](https://github.com/LuxDL/DocumenterVitepress.jl) and *italic* font
 
 This was previously breaking due to special markdown characters in the slug.
 


### PR DESCRIPTION
Fixes https://github.com/LuxDL/DocumenterVitepress.jl/issues/143 in a dumb way, by just removing the offending special markdown characters from the slug. But escaping them didn't work, they still broke vitepress. And it seemed unlikely to me that the removal would add new conflicts between previously unique headings. Unless someone adds the same link with different markdown stylings, but that seems rather nonsensical to do.