### PR TITLE
fix windows build

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -1,8 +1,8 @@
 {
   "devDependencies": {
-    "@nolebase/vitepress-plugin-enhanced-readabilities": "^2.14.0",
+    "@nolebase/vitepress-plugin-enhanced-readabilities": "^2.15.0",
     "@types/d3-format": "^3.0.4",
-    "@types/node": "^22.13.4",
+    "@types/node": "^22.13.9",
     "markdown-it": "^14.1.0",
     "markdown-it-mathjax3": "^4.3.2",
     "vitepress": "^1.6.3",
@@ -11,6 +11,7 @@
   "scripts": {
     "docs:dev": "vitepress dev build/.documenter",
     "docs:build": "vitepress build build/.documenter",
+    "docs:build:debug": "set DEBUG=vitepress:* && vitepress build build/.documenter",
     "docs:preview": "vitepress preview build/.documenter"
   },
   "dependencies": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,7 +11,6 @@
   "scripts": {
     "docs:dev": "vitepress dev build/.documenter",
     "docs:build": "vitepress build build/.documenter",
-    "docs:build:debug": "set DEBUG=vitepress:* && vitepress build build/.documenter",
     "docs:preview": "vitepress preview build/.documenter"
   },
   "dependencies": {

--- a/docs/src/.vitepress/config.mts
+++ b/docs/src/.vitepress/config.mts
@@ -31,6 +31,8 @@ export default defineConfig({
   lastUpdated: true,
   cleanUrls: true,
   outDir: 'REPLACE_ME_DOCUMENTER_VITEPRESS', // This is required for MarkdownVitepress to work correctly...
+  ignoreDeadLinks: true,
+  
   head: [
     ['link', { rel: 'icon', href: 'REPLACE_ME_DOCUMENTER_VITEPRESS_FAVICON' }],
     ['script', {src: `${getBaseRepository(baseTemp.base)}versions.js`}],

--- a/docs/src/.vitepress/config.mts
+++ b/docs/src/.vitepress/config.mts
@@ -2,6 +2,9 @@ import { defineConfig } from 'vitepress'
 import { tabsMarkdownPlugin } from 'vitepress-plugin-tabs'
 import mathjax3 from "markdown-it-mathjax3";
 import footnote from "markdown-it-footnote";
+import path from 'path'
+
+// console.log(process.env)
 
 function getBaseRepository(base: string): string {
   if (!base || base === '/') return '/';
@@ -31,7 +34,6 @@ export default defineConfig({
   lastUpdated: true,
   cleanUrls: true,
   outDir: 'REPLACE_ME_DOCUMENTER_VITEPRESS', // This is required for MarkdownVitepress to work correctly...
-  ignoreDeadLinks: true,
   
   head: [
     ['link', { rel: 'icon', href: 'REPLACE_ME_DOCUMENTER_VITEPRESS_FAVICON' }],
@@ -40,6 +42,11 @@ export default defineConfig({
     ['script', {src: `${baseTemp.base}siteinfo.js`}]
   ],
   vite: {
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, '../components')
+      }
+    },
     build: {
       assetsInlineLimit: 0, // so we can tell whether we have created inlined images or not, we don't let vite inline them
     },

--- a/docs/src/.vitepress/theme/index.ts
+++ b/docs/src/.vitepress/theme/index.ts
@@ -8,11 +8,11 @@ import {
   NolebaseEnhancedReadabilitiesScreenMenu, 
 } from '@nolebase/vitepress-plugin-enhanced-readabilities/client'
 
-import AsideTrustees from '../../components/AsideTrustees.vue'
-import VersionPicker from "../../components/VersionPicker.vue"
-import StarUs from '../../components/StarUs.vue'
-import AuthorBadge from '../../components/AuthorBadge.vue'
-import Authors from '../../components/Authors.vue'
+import AsideTrustees from '@/AsideTrustees.vue'
+import VersionPicker from "@/VersionPicker.vue"
+import StarUs from '@/StarUs.vue'
+import AuthorBadge from '@/AuthorBadge.vue'
+import Authors from '@/Authors.vue'
 import { enhanceAppWithTabs } from 'vitepress-plugin-tabs/client'
 
 import '@nolebase/vitepress-plugin-enhanced-readabilities/client/style.css'

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -80,9 +80,18 @@ This function takes the filename `file`, and returns a file path in the `mdfolde
 
 """
 function docpath(file, builddir, mdfolder)
-    path = relpath(file, builddir)
-    filename = mdext(path)
-    return joinpath(builddir, mdfolder, filename) 
+    # For Windows, handle the build prefix and get the relative part
+    if Sys.iswindows() && startswith(file, "build\\")
+        # Extract everything after "build\"
+        relative_part = split(file, "build\\")[2]
+        # Join with target directory structure
+        return normpath(joinpath(builddir, mdfolder, relative_part))
+    else
+        # Unix systems or non-build prefix
+        path = relpath(file, builddir)
+        filename = mdext(path)
+        return joinpath(builddir, mdfolder, filename)
+    end
 end
 
 """
@@ -190,6 +199,8 @@ function render(doc::Documenter.Document, settings::MarkdownVitepress=MarkdownVi
             for file in files[favicon_files]
                 file_relpath = relpath(file, joinpath(builddir, settings.md_output_path, "assets"))
                 file_destpath = joinpath(builddir, settings.md_output_path, "public", file_relpath)
+                dest_dir = dirname(file_destpath)
+                mkpath(dest_dir) # Ensure destination directory exists
                 if normpath(file) != normpath(file_destpath)
                     cp(file, file_destpath; force = true)
                 end
@@ -211,8 +222,10 @@ function render(doc::Documenter.Document, settings::MarkdownVitepress=MarkdownVi
     end
 
     mkpath(joinpath(builddir, "final_site"))
-    if isfile(joinpath(builddir, settings.md_output_path, ".vitepress", "config.mts"))
-        touch(joinpath(builddir, settings.md_output_path, ".vitepress", "config.mts"))
+    config_path = joinpath(builddir, settings.md_output_path, ".vitepress", "config.mts")
+    if isfile(config_path)
+        mkpath(dirname(config_path)) # Ensure .vitepress directory exists
+        touch(config_path)
     end
 
     # Now that the Markdown files are written, we can build the Vitepress site if required.

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -241,32 +241,38 @@ function render(doc::Documenter.Document, settings::MarkdownVitepress=MarkdownVi
             end
 
             cd(dirname(builddir)) do
-                # Use a platform-independent way to handle paths
+                # NodeJS_20_jll treats `npm` as a `FileProduct`, meaning that it has no associated environment variable
+                # when interpolating the `npm` command.  
+                # However, `node() do ...` actually uses `withenv` internally, so we can wrap all invocations of `npm` in
+                # a `node()` block to ensure that the `npm` from the JLL finds the `node` from the JLL.
+
                 package_json_path = joinpath(dirname(builddir), "package.json")
                 template_path = joinpath(dirname(@__DIR__), "template", "package.json")
                 build_output_path = joinpath(builddir, settings.md_output_path)
                 
-                node(; adjust_PATH = true, adjust_LIBPATH = true) do _
-                    if settings.install_npm || should_remove_package_json
-                        if !isfile(package_json_path)
-                            cp(template_path, package_json_path)
-                            should_remove_package_json = true
-                        end 
-                        # For Windows specifically, try different command construction
+                if settings.install_npm || should_remove_package_json
+                    if !isfile(package_json_path)
+                        cp(template_path, package_json_path)
+                        should_remove_package_json = true
+                    end
+                    # wrap in `node(...) do _`
+                    node(; adjust_PATH = true, adjust_LIBPATH = true) do _
+                        # On Windows systems
                         if Sys.iswindows()
-                            # Try with cmd /c to explicitly invoke Windows command processor
-                            run(`cmd /c "$(npm)" install`)
+                            # system_npm = "C:\\Program Files\\nodejs\\npm.cmd"
+                            @warn "On Windows, use `npm run docs:dev` and `npm run docs:build` directly in the terminal inside your `docs` folder."
+                            @info "Go to https://nodejs.org/en, download, and install the latest version. Version 22.11.0 or higher should work."
+                            # install dependecies
+                            run(`cmd /c $npm install`)
+                            # run(`cmd /c $npm exec vitepress build $build_output_path`) # activate once a new > NodeJS_20_jll artifact is available.
+                            # Debugging alternative
+                            # run(`cmd /c "set DEBUG=vitepress:* & $npm exec vitepress build $build_output_path"`)
                         else
                             run(`$(npm) install`)
+                            run(`$(npm) run env -- vitepress build $(build_output_path)`)
                         end
                     end
-                    # Similarly for the vitepress build command
-                    if Sys.iswindows()
-                        run(`cmd /c "$(npm)" exec vitepress build "$(build_output_path)"`)
-                    else
-                        run(`$(npm) run env -- vitepress build $(build_output_path)`)
-                    end
-                end
+                end                
             end
         catch e
             rethrow(e)

--- a/template/src/.vitepress/config.mts
+++ b/template/src/.vitepress/config.mts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vitepress'
 import { tabsMarkdownPlugin } from 'vitepress-plugin-tabs'
 import mathjax3 from "markdown-it-mathjax3";
 import footnote from "markdown-it-footnote";
+import path from 'path'
 
 function getBaseRepository(base: string): string {
   if (!base || base === '/') return '/';
@@ -38,8 +39,13 @@ export default defineConfig({
     // ['script', {src: '/versions.js'], for custom domains, I guess if deploy_url is available.
     ['script', {src: `${baseTemp.base}siteinfo.js`}]
   ],
-  ignoreDeadLinks: true,
+  
   vite: {
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, '../components')
+      }
+    },
     optimizeDeps: {
       exclude: [ 
         '@nolebase/vitepress-plugin-enhanced-readabilities/client',

--- a/template/src/.vitepress/theme/index.ts
+++ b/template/src/.vitepress/theme/index.ts
@@ -8,9 +8,9 @@ import {
   NolebaseEnhancedReadabilitiesScreenMenu, 
 } from '@nolebase/vitepress-plugin-enhanced-readabilities/client'
 
-import VersionPicker from "../../components/VersionPicker.vue"
-import AuthorBadge from '../../components/AuthorBadge.vue'
-import Authors from '../../components/Authors.vue'
+import VersionPicker from "@/VersionPicker.vue"
+import AuthorBadge from '@/AuthorBadge.vue'
+import Authors from '@/Authors.vue'
 
 import { enhanceAppWithTabs } from 'vitepress-plugin-tabs/client'
 


### PR DESCRIPTION
closes https://github.com/LuxDL/DocumenterVitepress.jl/issues/171

As is.

In order to `dev/build` correctly in windows I needed to be explicit about `components paths`.  That is,  in our config file we need to add: 

```
vite: {
    resolve: {
      alias: {
        '@': path.resolve(__dirname, '../components') # change as appropriate, if you have your components in another path.
      }
    },
```

and then when importing components in our `index.ts` file do 

```
import MyComponent from '@/MyComponent.vue'
```

This should allow you to dev and build your docs now locally.

```sh
docs> npm run docs:dev
```

This approach, requires you to have https://nodejs.org/en installed in your `windows` system. 
