### PR TITLE
feat: improve citations integration

### DIFF
--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -20,7 +20,7 @@ permissions:
   pages: write
   id-token: write
   statuses: write
-        
+
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
@@ -38,9 +38,6 @@ jobs:
         uses: julia-actions/setup-julia@v1
       - name: Pull Julia cache
         uses: julia-actions/cache@v1
-      - name: Install documentation dependencies
-        run: julia --project=docs -e 'using Pkg; pkg"dev ."; Pkg.instantiate(); Pkg.precompile(); Pkg.status()'
-      #- name: Creating new mds from src
       - name: Build and deploy docs
         uses: julia-actions/julia-docdeploy@v1
         env:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DocumenterVitepress"
 uuid = "4710194d-e776-4893-9690-8d956a29c365"
 authors = ["Lazaro Alonso <lazarus.alon@gmail.com>", "Anshul Singhvi <anshulsinghvi@gmail.com>"]
-version = "0.1.11"
+version = "0.1.12"
 
 [deps]
 ANSIColoredPrinters = "a4c015fc-c6ff-483c-b24f-f7ea428134e9"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,3 +2,6 @@
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterVitepress = "4710194d-e776-4893-9690-8d956a29c365"
 DocumenterCitations = "daee34ce-89f3-4625-b898-19384cb65244"
+
+[sources]
+DocumenterVitepress = { path = ".." }

--- a/docs/src/manual/citations.md
+++ b/docs/src/manual/citations.md
@@ -37,7 +37,6 @@ This is the default style (`style=:numeric`) used throughout the other pages of 
 ```@bibliography
 Pages = [@__FILE__]
 Style = :numeric
-Canonical = false
 ```
 
 ## [Author-year style](@id author_year_style)

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -965,6 +965,10 @@ function render(io::IO, mime::MIME"text/plain", node::Documenter.MarkdownAST.Nod
         println.((io,), eachline)
     end
 end
+# HTMLInline
+function render(io::IO, mime::MIME"text/plain", node::Documenter.MarkdownAST.Node, html::MarkdownAST.HTMLInline, page, doc; kwargs...)
+    println(io, html.html)
+end
 # Tables
 function render(io::IO, mime::MIME"text/plain", node::Documenter.MarkdownAST.Node, table::MarkdownAST.TableCell, page, doc; kwargs...)
     println("Encountered table cell!")


### PR DESCRIPTION
- removes the `# Bibliography` (DocumenterCitations.jl doesn't add that by default)
- if anchor is present, then we generate the list having the anchor
- adds rendering for HTMLInline