### PR TITLE
try using DocumenterInterLinks, see what happens

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,6 +2,7 @@
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterVitepress = "4710194d-e776-4893-9690-8d956a29c365"
 DocumenterCitations = "daee34ce-89f3-4625-b898-19384cb65244"
+DocumenterInterLinks = "d12716ef-a0f6-4df4-a9f1-a5a34e75c656"
 
 [sources]
 DocumenterVitepress = { path = ".." }

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,6 +1,7 @@
 using Documenter
 using DocumenterVitepress
 using DocumenterCitations
+using DocumenterInterLinks
 
 # Handle DocumenterCitations integration - if you're running this, then you don't need anything here!!
 documenter_citations_dir = dirname(dirname(pathof(DocumenterCitations)))
@@ -23,6 +24,17 @@ bib = CitationBibliography(
     joinpath(@__DIR__, "src", "refs.bib");
     style=:numeric  # default
 )
+
+# Handle DocumenterInterLinks integration
+links = InterLinks(
+    "sphinx" => "https://www.sphinx-doc.org/en/master/",
+    "Documenter" => (
+        "https://documenter.juliadocs.org/stable/",
+        "https://documenter.juliadocs.org/stable/objects.inv",
+    ),
+);
+
+
 # dev local
 
 makedocs(; 
@@ -57,7 +69,7 @@ makedocs(;
         ],
         "api.md",
     ],
-    plugins = [bib,],
+    plugins = [bib, links],
 )
 
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -4,6 +4,9 @@ outline: deep
 ---
 ```
 
+See also the section about Documenter's [Writers](@extref Documenter).
+
+
 ## Public API
 
 ```@meta


### PR DESCRIPTION
This should work provided that the InterLinks processing runs before RenderDocument, which I presume it does.  Vitepress does not touch anything before that.