### PR TITLE
Fix "update to vitepress" example in docs

### DIFF
--- a/docs/src/manual/documenter_to_vitepress_docs_example.md
+++ b/docs/src/manual/documenter_to_vitepress_docs_example.md
@@ -71,7 +71,7 @@ Then the very first step here is to update the `make.jl` file to follow the Docu
        ],
    )
 
-   deploydocs(;
+   DocumenterVitepress.deploydocs(;
        repo = "github.com/ExampleOrg/Example.jl",
        target = "build", # this is where Vitepress stores its output
        devbranch = "main",


### PR DESCRIPTION
The manual does not show using `DocumenterVitepress` for the `deploydocs` function as explained in the project README.