### PR TITLE
VersionPicker fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fixed occasional double slashes in version picker URLs and remove the unnecessary current version from the bottom of the version list [#272](https://github.com/LuxDL/DocumenterVitepress.jl/pull/272).
+
 ## v0.2.2 - 2025-05-21
 
 - Fixed relative path to favicon in vitepress config [#265](https://github.com/LuxDL/DocumenterVitepress.jl/pull/265).

--- a/template/src/components/VersionPicker.vue
+++ b/template/src/components/VersionPicker.vue
@@ -53,6 +53,10 @@ const waitForScriptsToLoad = () => {
 const loadVersions = async () => {
   if (typeof window === 'undefined') return;
 
+  console.log(absoluteRoot);
+  console.log(absoluteOrigin);
+  console.log(joinPath(absoluteOrigin, '/dev/');
+
   try {
     if (isLocalBuild()) {
       versions.value = [{ text: 'dev', link: '/' }];

--- a/template/src/components/VersionPicker.vue
+++ b/template/src/components/VersionPicker.vue
@@ -19,7 +19,12 @@ function joinPath(base: string, path: string) {
 }
 
 const absoluteRoot = __DEPLOY_ABSPATH__;
-const absoluteOrigin = (typeof window === 'undefined' ? '' : window.location.origin) + absoluteRoot;
+const siteOrigin = (typeof window === 'undefined' ? '' : window.location.origin);
+
+function absoluteUrl(relative) {
+  const withRoot = joinPath(absoluteRoot, relative);
+  return siteOrigin + withRoot; // don't call `joinPath` on https:// part to not remove double slashes there
+}
 
 const props = defineProps<{ screenMenu?: boolean }>();
 const versions = ref<Array<{ text: string, link: string, class?: string }>>([]);
@@ -53,10 +58,6 @@ const waitForScriptsToLoad = () => {
 const loadVersions = async () => {
   if (typeof window === 'undefined') return;
 
-  console.log(absoluteRoot);
-  console.log(absoluteOrigin);
-  console.log(joinPath(absoluteOrigin, '/dev/'));
-
   try {
     if (isLocalBuild()) {
       versions.value = [{ text: 'dev', link: '/' }];
@@ -67,17 +68,17 @@ const loadVersions = async () => {
       if (scriptsLoaded && window.DOC_VERSIONS && window.DOCUMENTER_CURRENT_VERSION) {
         versions.value = window.DOC_VERSIONS.map(v => ({
           text: v,
-          link: joinPath(absoluteOrigin, `/${v}/`),
+          link: absoluteUrl(`/${v}/`),
         }));
         currentVersion.value = window.DOCUMENTER_CURRENT_VERSION;
       } else {
-        versions.value = [{ text: 'dev', link: joinPath(absoluteOrigin, '/dev/') }];
+        versions.value = [{ text: 'dev', link: absoluteUrl('/dev/') }];
         currentVersion.value = 'dev';
       }
     }
   } catch (error) {
     console.warn('Error loading versions:', error);
-    versions.value = [{ text: 'dev', link: joinPath(absoluteOrigin, '/dev/') }];
+    versions.value = [{ text: 'dev', link: absoluteUrl('/dev/') }];
     currentVersion.value = 'dev';
   }
   isClient.value = true;

--- a/template/src/components/VersionPicker.vue
+++ b/template/src/components/VersionPicker.vue
@@ -2,7 +2,7 @@
 
 <script setup lang="ts">
 import { ref, onMounted, computed} from 'vue'
-import { useData } from 'vitepress'
+import { useData, joinPath } from 'vitepress'
 import VPNavBarMenuGroup from 'vitepress/dist/client/theme-default/components/VPNavBarMenuGroup.vue'
 import VPNavScreenMenuGroup from 'vitepress/dist/client/theme-default/components/VPNavScreenMenuGroup.vue'
 
@@ -56,20 +56,19 @@ const loadVersions = async () => {
       const scriptsLoaded = await waitForScriptsToLoad();
 
       if (scriptsLoaded && window.DOC_VERSIONS && window.DOCUMENTER_CURRENT_VERSION) {
-        const allVersions = new Set([...window.DOC_VERSIONS, window.DOCUMENTER_CURRENT_VERSION]);
-        versions.value = Array.from(allVersions).map(v => ({
+        versions.value = window.DOC_VERSIONS.map(v => ({
           text: v,
-          link: `${absoluteOrigin}/${v}/`
+          link: joinPath(absoluteOrigin, `/${v}/`),
         }));
         currentVersion.value = window.DOCUMENTER_CURRENT_VERSION;
       } else {
-        versions.value = [{ text: 'dev', link: `${absoluteOrigin}/dev/` }];
+        versions.value = [{ text: 'dev', link: joinPath(absoluteOrigin, '/dev/') }];
         currentVersion.value = 'dev';
       }
     }
   } catch (error) {
     console.warn('Error loading versions:', error);
-    versions.value = [{ text: 'dev', link: `${absoluteOrigin}/dev/` }];
+    versions.value = [{ text: 'dev', link: joinPath(absoluteOrigin, '/dev/') }];
     currentVersion.value = 'dev';
   }
   isClient.value = true;

--- a/template/src/components/VersionPicker.vue
+++ b/template/src/components/VersionPicker.vue
@@ -55,7 +55,7 @@ const loadVersions = async () => {
 
   console.log(absoluteRoot);
   console.log(absoluteOrigin);
-  console.log(joinPath(absoluteOrigin, '/dev/');
+  console.log(joinPath(absoluteOrigin, '/dev/'));
 
   try {
     if (isLocalBuild()) {

--- a/template/src/components/VersionPicker.vue
+++ b/template/src/components/VersionPicker.vue
@@ -2,7 +2,7 @@
 
 <script setup lang="ts">
 import { ref, onMounted, computed} from 'vue'
-import { useData, joinPath } from 'vitepress'
+import { useData } from 'vitepress'
 import VPNavBarMenuGroup from 'vitepress/dist/client/theme-default/components/VPNavBarMenuGroup.vue'
 import VPNavScreenMenuGroup from 'vitepress/dist/client/theme-default/components/VPNavScreenMenuGroup.vue'
 
@@ -11,6 +11,11 @@ declare global {
     DOC_VERSIONS?: string[];
     DOCUMENTER_CURRENT_VERSION?: string;
   }
+}
+
+// from vitepress, MIT
+function joinPath(base: string, path: string) {
+  return `${base}${path}`.replace(/\/+/g, '/')
 }
 
 const absoluteRoot = __DEPLOY_ABSPATH__;


### PR DESCRIPTION
Currently the version picker in AoG looks like this

<img width="197" alt="image" src="https://github.com/user-attachments/assets/3402b4b2-bc9d-41b1-b926-c616393d2baf" />

I think the current version at the bottom is unnecessary, it's the same one that's shown at the top anyway if you're on stable (it's mostly needed for the warning functionality which we don't have yet)

Also, the URLs there are wrong because they contain a double slash

<img width="252" alt="image" src="https://github.com/user-attachments/assets/00ae2df6-1956-4bfa-9ee9-0e19ed415c8f" />

This PR should fix both problems