### PR TITLE
Skip empty bases when deploying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## v0.2.4 - 2025-05-26
+
+- Skip empty bases when deploying to not overwrite all docs accidentally [#274](https://github.com/LuxDL/DocumenterVitepress.jl/pull/274).
+
 ## v0.2.3 - 2025-05-25
 
 - Fixed occasional double slashes in version picker URLs and removed the unnecessary current version from the bottom of the version list [#272](https://github.com/LuxDL/DocumenterVitepress.jl/pull/272).

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DocumenterVitepress"
 uuid = "4710194d-e776-4893-9690-8d956a29c365"
 authors = ["Lazaro Alonso <lazarus.alon@gmail.com>", "Anshul Singhvi <anshulsinghvi@gmail.com>", "Julius Krumbiegel"]
-version = "0.2.3"
+version = "0.2.4"
 
 [deps]
 ANSIColoredPrinters = "a4c015fc-c6ff-483c-b24f-f7ea428134e9"

--- a/src/DocumenterVitepress.jl
+++ b/src/DocumenterVitepress.jl
@@ -153,7 +153,11 @@ function deploydocs(;
     if !isfile(bases_file)
         error("Expected a file at $bases_file listing the separate bases that DocumenterVitepress has built the docs for.")
     end
-    bases = readlines(bases_file)
+    bases = filter(!isempty, readlines(bases_file))
+    if isempty(bases)
+        @info "Found no bases suitable for deployment (empty bases are skipped)."
+        return
+    end
     @info "Found bases for deployment: $bases"
 
     for (i, base) in enumerate(bases)


### PR DESCRIPTION
The Makie docs just got nuked by a PR introducing DV 0.2, because of a weird coincidence where the first internal calculation of the deploy parameters did this:

```
┌ Warning: Unable to verify if PR comes from destination repository -- assuming it doesn't.
└ @ Documenter ~/.julia/packages/Documenter/iRt2s/src/deployconfig.jl:547
┌ Info: Deployment criteria for deploying preview build from GitHub Actions:
│ - ✔ ENV["GITHUB_REPOSITORY"]="MakieOrg/Makie.jl" occurs in repo="github.com/MakieOrg/Makie.jl"
│ - ✔ ENV["GITHUB_REF"] corresponds to a PR number
│ - ✘ PR originates from the same repository
│ - ✔ `push_preview` keyword argument to deploydocs is `true`
│ - ✔ ENV["GITHUB_ACTOR"] exists and is non-empty
│ - ✔ ENV["GITHUB_TOKEN"] exists and is non-empty
└ Deploying: ✘
```

which resulted in the base `""` (which always happens if we don't deploy). This is ok in principle because it allows local builds to proceed, and the empty base is good for local viewing.

The reason for the `Unable to verify` was that Github was having intermittent server problems just at this time. And that was a problem, because we auto-determine the deploy parameters twice, and the next time it worked again:

```
[ Info: Found bases for deployment: [""]
[ Info: Deploying docs for base "" from build/1
┌ Info: Deployment criteria for deploying preview build from GitHub Actions:
│ - ✔ ENV["GITHUB_REPOSITORY"]="MakieOrg/Makie.jl" occurs in repo="github.com/MakieOrg/Makie.jl.git"
│ - ✔ ENV["GITHUB_REF"] corresponds to a PR number
│ - ✔ PR originates from the same repository
│ - ✔ `push_preview` keyword argument to deploydocs is `true`
│ - ✔ ENV["GITHUB_ACTOR"] exists and is non-empty
│ - ✔ ENV["GITHUB_TOKEN"] exists and is non-empty
└ Deploying: ✔
```

So then this proceeded to deploy to the originally determined base `""` which effectively overwrote all docs, which luckily could be restored from an earlier commit. So this PR is a quick fix that just skips deployment of empty bases, because currently we don't have specific guard rails for this case, and almost nobody I think deploys DV into a versionless scheme anyway. If they do, we can reintroduce a safer variant later. 