### PR TITLE
Better sidebar/navbar rendering from the Documenter end

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,6 +4,45 @@ using DocumenterCitations
 using DocumenterInterLinks
 using LaTeXStrings
 
+struct DecomposeInSidebar
+    path::String
+    pages::Any
+end
+
+# So you can only really pull this trick once in a Julia session
+# But because doc.user.pages is a Vector{Any}, we can't really do anything about it.
+function DocumenterVitepress.pagelist2str(doc, ds::Vector{<: Any}, ::Val{:sidebar})
+    println("Hello World!!!")
+    if !all(x -> x isa DecomposeInSidebar, ds)
+        # if this is false, invoke the default method.
+        return invoke(pagelist2str, Tuple{Any, Any, Val{:sidebar}}, doc, ds, Val(:sidebar))
+    end
+    contents = DocumenterVitepress.pagelist2str.((doc,), ds, (Val(:sidebar),))
+    ret = "{\n" * join(contents, ",\n") * "\n}"
+    println(ret)
+    return ret
+end
+
+function DocumenterVitepress.pagelist2str(doc, ds::DecomposeInSidebar, ::Val{:sidebar})
+    raw_contents = DocumenterVitepress.pagelist2str(doc, ds.pages, Val(:sidebar))
+    contents = if raw_contents isa String
+        raw_contents
+    else
+        join(raw_contents, ",\n")
+    end
+
+    return "\"/$(ds.path)/\": {\n$(contents)\n}"
+end
+
+function DocumenterVitepress.pagelist2str(doc, ds::DecomposeInSidebar, ::Val{:navbar})
+    return DocumenterVitepress.pagelist2str(doc, ds.pages, Val(:sidebar))
+end
+
+function Documenter.walk_navpages(ds::DecomposeInSidebar, parent, doc)
+    return Documenter.walk_navpages(ds.pages, parent, doc)
+end
+
+
 # Handle DocumenterCitations integration - if you're running this, then you don't need anything here!!
 documenter_citations_dir = dirname(dirname(pathof(DocumenterCitations)))
 documenter_citations_docs_dir = joinpath(documenter_citations_dir, "docs")
@@ -53,7 +92,7 @@ makedocs(;
     source = "src",
     build = "build",
     pages = [
-        "Manual" => [
+        DecomposeInSidebar("manual", "Manual" => [
             "Get Started" => "manual/get_started.md",
             "Updating to DocumenterVitepress" => "manual/documenter_to_vitepress_docs_example.md",
             "Code" => "manual/code_example.md",
@@ -63,12 +102,11 @@ makedocs(;
             "CSS Styling" => "manual/style_css.md",
             "Authors' badge" => "manual/author_badge.md",
             "GitHub Icon with Stars" => "manual/repo_stars.md",
-        ],
-        "Developers' documentation" => [
+        ]),
+        DecomposeInSidebar("devs", "Developers' documentation" => [
             "The rendering process" => "devs/render_pipeline.md",
             "Internal API" => "devs/internal_api.md",
-        ],
-        "api.md",
+        ]),
     ],
     plugins = [bib, links],
 )

--- a/src/DocumenterVitepress.jl
+++ b/src/DocumenterVitepress.jl
@@ -15,6 +15,7 @@ const ASSETS = normpath(joinpath(@__DIR__, "..", "assets"))
 
 include("vitepress_interface.jl")
 include("vitepress_config.jl")
+include("frontmatter.jl")
 include("writer.jl")
 include("ANSIBlocks.jl")
 

--- a/src/frontmatter.jl
+++ b/src/frontmatter.jl
@@ -13,6 +13,13 @@ function merge_and_render_frontmatter(io::IO, mime::MIME"text/yaml", page, doc; 
             push!(frontmatter, join(split(element.text, "\n")[2:end-1], "\n"))
         end
     end
+
+    if haskey(page.globals.meta, :Title)
+        pushfirst!(frontmatter, "title: \"$(page.globals.meta[:Title])\"")
+    end
+    if haskey(page.globals.meta, :Description)
+        pushfirst!(frontmatter, "description: \"$(page.globals.meta[:Description])\"")
+    end
     println(io, "---")
     println(io, join(frontmatter, "\n"))
     println(io, "---")

--- a/src/frontmatter.jl
+++ b/src/frontmatter.jl
@@ -1,0 +1,19 @@
+# In Vitepress you can only have one frontmatter block.
+# But users / other Documenter stages may inject multiple.
+# So, we have a stage that will merge and render all frontmatter blocks
+# before doing anything else.
+
+function merge_and_render_frontmatter(io::IO, mime::MIME"text/yaml", page, doc; kwargs...)
+    frontmatter = String[]
+    for block in page.mdast.children
+        element = block.element
+        if element isa MarkdownAST.CodeBlock && element.info == "@frontmatter"
+            push!(frontmatter, element.code)
+        elseif element isa Documenter.RawNode && startswith(element.text, "---")
+            push!(frontmatter, join(split(element.text, "\n")[2:end-1], "\n"))
+        end
+    end
+    println(io, "---")
+    println(io, join(frontmatter, "\n"))
+    println(io, "---")
+end

--- a/src/vitepress_config.jl
+++ b/src/vitepress_config.jl
@@ -89,9 +89,14 @@ function modify_config_file(doc, settings, deploy_decision, i_folder, base)
             @info "Base is \"\" and ENV[\"CI\"] is not set so this is a local build. Not adding any additional base prefix based on the repository or deploy url and instead using absolute path \"/\" to facilitate serving docs locally."
             "/"
         elseif isnothing(settings.deploy_url)
-            "/" * splitpath(settings.repo)[end]  # Get the last identifier of the repo path, i.e., `user/$repo`.
+            "/" * split(settings.repo, '/')[end]  # Get the last identifier of the repo path, i.e., `user/$repo`.
         else
-            s_path = startswith(settings.deploy_url, r"http[s?]:\/\/") ? splitpath(settings.deploy_url)[2:end] : splitpath(settings.deploy_url)
+            s_path = if startswith(settings.deploy_url, r"http[s?]:\/\/")
+                frags = split(settings.deploy_url, '/') # "https", "", "my.custom.domain", "sub", "dir"
+                length(frags) > 3 ? frags[3:end] : "/" #                               |-> "sub", "dir"
+            else
+                split(settings.deploy_url, '/') # "sub", "dir"
+            end
             s = length(s_path) > 1 ? joinpath(s_path) : "" # ignore custom URL here
             isempty(s) ? "/" : "/$(s)"
         end

--- a/src/vitepress_config.jl
+++ b/src/vitepress_config.jl
@@ -93,7 +93,7 @@ function modify_config_file(doc, settings, deploy_decision, i_folder, base)
         else
             s_path = if startswith(settings.deploy_url, r"http[s?]:\/\/")
                 frags = split(settings.deploy_url, '/') # "https", "", "my.custom.domain", "sub", "dir"
-                length(frags) >= 4 ? frags[4:end] : "/" #                               |-> "sub", "dir"
+                length(frags) >= 4 ? frags[4:end] : [""] #                             |-> "sub", "dir"
             else
                 split(settings.deploy_url, '/') # "sub", "dir"
             end
@@ -101,7 +101,7 @@ function modify_config_file(doc, settings, deploy_decision, i_folder, base)
             isempty(s) ? "/" : "/$(s)"
         end
 
-    base_str = deploy_abspath == "/" ? "base: '$(deploy_abspath)$(deploy_relpath)'" : "base: '$(deploy_abspath)/$(deploy_relpath)'"
+    base_str = endswith(deploy_abspath, "/") ? "base: '$(deploy_abspath)$(deploy_relpath)'" : "base: '$(deploy_abspath)/$(deploy_relpath)'"
 
     push!(replacers, "REPLACE_ME_DOCUMENTER_VITEPRESS_DEPLOY_ABSPATH" => deploy_abspath)
     push!(replacers, "base: 'REPLACE_ME_DOCUMENTER_VITEPRESS'" => base_str)

--- a/src/vitepress_config.jl
+++ b/src/vitepress_config.jl
@@ -211,7 +211,12 @@ function pagelist2str(doc, name_contents::Pair{<: AbstractString, <: AbstractArr
         "{" * pagelist2str(doc, content, sidenav) * "}"
     end
     final_contents = join(rendered_contents, ",\n")
-    return "text: '$(replace(name, "'" => "\\'"))', collapsed: false, items: [\n$(final_contents)\n]" # TODO: add a link here if the name is the same name as a file?
+    collapse = if sidenav === Val(:sidebar)
+        "collapsed: false,"
+    else
+        ""
+    end
+    return "text: '$(replace(name, "'" => "\\'"))', $collapse items: [\n$(final_contents)\n]" # TODO: add a link here if the name is the same name as a file?
 end
 
 function _item_link(page, item)

--- a/src/vitepress_config.jl
+++ b/src/vitepress_config.jl
@@ -188,12 +188,23 @@ function pagelist2str(doc, page::AbstractString, sidenav::Val)
     name = get_title(doc, page)
     return "text: '$(replace(name, "'" => "\\'"))', link: '/$(splitext(page)[1])'" # , $(sidebar_items(doc, page)) }"
 end
+
+function pagelist2str(doc, name_page::Pair{<: Any, <: Any}, sidenav::Val)
+    name, page = name_page
+    # This is the simplest and easiest case.
+    return pagelist2str(doc, name => page, sidenav) # , $(sidebar_items(doc, page)) }"
+end
+
+function pagelist2str(doc, name_page::Pair{<: Any, <: Nothing}, sidenav::Val)
+    return ""
+end
+
 function pagelist2str(doc, name_page::Pair{<: AbstractString, <: AbstractString}, sidenav::Val)
     name, page = name_page
     # This is the simplest and easiest case.
     return "text: '$(replace(name, "'" => "\\'"))', link: '/$(splitext(page)[1])'" # , $(sidebar_items(doc, page)) }"
 end
-function pagelist2str(doc, name_contents::Pair{<: AbstractString, <: AbstractVector}, sidenav::Val)
+function pagelist2str(doc, name_contents::Pair{<: AbstractString, <: AbstractArray}, sidenav::Val)
     name, contents = name_contents
     # This is for nested stuff.  Should work automatically but you never know...
     rendered_contents = map(contents) do content

--- a/src/vitepress_config.jl
+++ b/src/vitepress_config.jl
@@ -93,11 +93,11 @@ function modify_config_file(doc, settings, deploy_decision, i_folder, base)
         else
             s_path = if startswith(settings.deploy_url, r"http[s?]:\/\/")
                 frags = split(settings.deploy_url, '/') # "https", "", "my.custom.domain", "sub", "dir"
-                length(frags) > 3 ? frags[3:end] : "/" #                               |-> "sub", "dir"
+                length(frags) >= 4 ? frags[4:end] : "/" #                               |-> "sub", "dir"
             else
                 split(settings.deploy_url, '/') # "sub", "dir"
             end
-            s = length(s_path) > 1 ? joinpath(s_path) : "" # ignore custom URL here
+            s = join(s_path, '/')
             isempty(s) ? "/" : "/$(s)"
         end
 

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -256,9 +256,10 @@ function render(doc::Documenter.Document, settings::MarkdownVitepress=MarkdownVi
             push!(inventory, item)
         end
     end
-
-    objects_inv = joinpath(builddir, settings.md_output_path, "public", "objects.inv")
-    DocInventories.save(objects_inv, inventory)
+    if settings.write_inventory
+        objects_inv = joinpath(builddir, settings.md_output_path, "public", "objects.inv")
+        DocInventories.save(objects_inv, inventory)
+    end
 
     bases = determine_bases(deploy_decision.subfolder; settings.keep)
 

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -949,6 +949,9 @@ render(io::IO, mime::MIME"text/plain", node::MarkdownAST.Node, ::Documenter.Setu
 # Raw nodes are used to insert raw HTML into the output. We just print it as is.
 # TODO: what if the `raw` is not HTML?  That is not addressed here but we ought to address it...
 function render(io::IO, ::MIME"text/plain", node::Documenter.MarkdownAST.Node, raw::Documenter.RawNode, page, doc; kwargs...)
+    if startswith(raw.text, "---")
+        return # this was already handled by frontmatter.
+    end
     return raw.name === :html ? println(io, raw.text, "\n") : nothing
 end
 

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -228,6 +228,7 @@ function render(doc::Documenter.Document, settings::MarkdownVitepress=MarkdownVi
     for (src, page) in doc.blueprint.pages
         # This is where you can operate on a per-page level.
         open(docpath(page.build, builddir, settings.md_output_path), "w") do io
+            merge_and_render_frontmatter(io, MIME("text/yaml"), page, doc)
             for node in page.mdast.children
                 render(io, mime, node, page, doc; inventory)
             end


### PR DESCRIPTION
This allows an extensible interface (and significantly cleans up the interface in general).  `(doc::Documenter.Document).user.pages` is strictly typed to be a Vector{Any} so we can't dispatch intelligently on that, but you can carve out a single dispatch on Vector{<: Any} that will let you interrogate the structure of an array.  Can only do that once per Julia session.

This lets us do in Julia what the Lux docs do manually. Specifically, note how the sidebar changes here.

https://github.com/user-attachments/assets/ba7aa867-f6b4-443b-be6e-7306388b3427




