### PR TITLE
Pass through all admonitions without enforcing "tip". 

### DIFF
--- a/src/writer.jl
+++ b/src/writer.jl
@@ -1054,12 +1054,6 @@ function render(io::IO, mime::MIME"text/plain", node::Documenter.MarkdownAST.Nod
         category = "tip"
     end
     title = admonition.title
-    if !(category ∈ ("tip", "warning", "danger", "caution"))
-        if isempty(admonition.title)
-            admonition.title = category
-        end
-        category = "tip"
-    end
     println(io, "\n::: $(category) $(title)")
     render(io, mime, node, node.children, page, doc; kwargs...)
     println(io, "\n:::")


### PR DESCRIPTION
This PR simply allow admonitions that are not in the vitepress list to be passed through, and let vitepress handle them.

Should help with #95 and #288.