### PR TITLE
Bump minimum supported julia version to 1.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DocumenterVitepress"
 uuid = "4710194d-e776-4893-9690-8d956a29c365"
 authors = ["Lazaro Alonso <lazarus.alon@gmail.com>", "Anshul Singhvi <anshulsinghvi@gmail.com>", "Julius Krumbiegel"]
-version = "0.2.7"
+version = "0.2.8"
 
 [deps]
 ANSIColoredPrinters = "a4c015fc-c6ff-483c-b24f-f7ea428134e9"


### PR DESCRIPTION
1.10 is the current LTS release and compatibility with 1.6 cannot be maintained