### PR TITLE
ssr deps exclude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## unreleased
-
+- configuring Vite to exclude `@mathjax/mathjax-newcm-font`, `mathjax-full`, and `@mdit/plugin-mathjax` from its dependency optimization and externalization processes [#304](https://github.com/LuxDL/DocumenterVitepress.jl/pull/304).
 - Switched to `@mdit/plugin-mathjax` from `markdown-it-mathjax3` in order to support labels and referencing equations [#302](https://github.com/LuxDL/DocumenterVitepress.jl/pull/302).
 - Renamed `master` to `main`
 

--- a/docs/src/.vitepress/config.mts
+++ b/docs/src/.vitepress/config.mts
@@ -22,6 +22,11 @@ if (!mathjaxInstance) {
 const virtualModuleId = 'virtual:mathjax-styles.css';
 const resolvedVirtualModuleId = '\0' + virtualModuleId;
 
+const mathjaxDeps = [
+  '@mathjax/mathjax-newcm-font',
+  'mathjax-full',
+];
+
 function getBaseRepository(base: string): string {
   if (!base || base === '/') return '/';
   const parts = base.split('/').filter(Boolean);
@@ -105,8 +110,7 @@ export default defineConfig({
         '@nolebase/vitepress-plugin-enhanced-readabilities/client',
         'vitepress',
         '@nolebase/ui',
-        '@mathjax/mathjax-newcm-font',
-        'mathjax-full',
+        ...mathjaxDeps,
       ], 
     }, 
     ssr: { 
@@ -114,8 +118,7 @@ export default defineConfig({
         // If there are other packages that need to be processed by Vite, you can add them here.
         '@nolebase/vitepress-plugin-enhanced-readabilities',
         '@nolebase/ui',
-        '@mathjax/mathjax-newcm-font',
-        'mathjax-full',
+        ...mathjaxDeps,
         '@mdit/plugin-mathjax',
       ], 
     },

--- a/template/src/.vitepress/config.mts
+++ b/template/src/.vitepress/config.mts
@@ -20,6 +20,11 @@ if (!mathjaxInstance) {
 const virtualModuleId = 'virtual:mathjax-styles.css';
 const resolvedVirtualModuleId = '\0' + virtualModuleId;
 
+const mathjaxDeps = [
+  '@mathjax/mathjax-newcm-font',
+  'mathjax-full',
+];
+
 function getBaseRepository(base: string): string {
   if (!base || base === '/') return '/';
   const parts = base.split('/').filter(Boolean);
@@ -101,8 +106,7 @@ export default defineConfig({
         '@nolebase/vitepress-plugin-enhanced-readabilities/client',
         'vitepress',
         '@nolebase/ui',
-        '@mathjax/mathjax-newcm-font',
-        'mathjax-full',
+        ...mathjaxDeps,
       ], 
     }, 
     ssr: { 
@@ -110,8 +114,7 @@ export default defineConfig({
         // If there are other packages that need to be processed by Vite, you can add them here.
         '@nolebase/vitepress-plugin-enhanced-readabilities',
         '@nolebase/ui',
-        '@mathjax/mathjax-newcm-font',
-        'mathjax-full',
+        ...mathjaxDeps,
         '@mdit/plugin-mathjax',
       ], 
     },


### PR DESCRIPTION
No issue in normal CI and it doesn't hurt, but this might help for this `buildkite` issue:

```
<head></head>
Can't load '@mathjax/mathjax-newcm-font/svg/dynamic/script.js': No mathjax.asyncLoad method specified
--
x Build failed in 316ms
✖ building client + server bundles...
Can't load '@mathjax/mathjax-newcm-font/svg/dynamic/symbols.js': No mathjax.asyncLoad method specified
file:///var/lib/buildkite-agent/Oceananigans.jl-28776/docs/node_modules/@mathjax/src/mjs/output/common/FontData.js:286
return Promise.reject(new Error(`dynamic file '${dynamic.file}' failed to load`));
^
 
Error: dynamic file 'symbols' failed to load
at MathJaxNewcmFont.<anonymous> (file:///var/lib/buildkite-agent/Oceananigans.jl-28776/docs/node_modules/@mathjax/src/mjs/output/common/FontData.js:286:39)
at Generator.next (<anonymous>)
at file:///var/lib/buildkite-agent/Oceananigans.jl-28776/docs/node_modules/@mathjax/src/mjs/output/common/FontData.js:7:71
at new Promise (<anonymous>)
at __awaiter (file:///var/lib/buildkite-agent/Oceananigans.jl-28776/docs/node_modules/@mathjax/src/mjs/output/common/FontData.js:3:12)
at MathJaxNewcmFont.loadDynamicFile (file:///var/lib/buildkite-agent/Oceananigans.jl-28776/docs/node_modules/@mathjax/src/mjs/output/common/FontData.js:284:16)
at MathJaxNewcmFont.getChar (file:///var/lib/buildkite-agent/Oceananigans.jl-28776/docs/node_modules/@mathjax/src/mjs/output/common/FontData.js:358:29)
at SvgTextNode.getVariantChar (file:///var/lib/buildkite-agent/Oceananigans.jl-28776/docs/node_modules/@mathjax/src/mjs/output/common/Wrapper.js:645:32)
at SvgTextNode.computeBBox (file:///var/lib/buildkite-agent/Oceananigans.jl-28776/docs/node_modules/@mathjax/src/mjs/output/common/Wrappers/TextNode.js:22:50)
at SvgTextNode.getBBox (file:///var/lib/buildkite-agent/Oceananigans.jl-28776/docs/node_modules/@mathjax/src/mjs/output/common/Wrapper.js:117:14)

```