### PR TITLE
slightly breaking release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## unreleased
+## v0.3.0 - 2026-01-02
 - updates get started section, now is consistent with README [#313](https://github.com/LuxDL/DocumenterVitepress.jl/pull/313)
 - parses plain \eqref and \ref. [#312](https://github.com/LuxDL/DocumenterVitepress.jl/pull/312).
 - template updates and mathjax-plugin cleanup. Fixes equations width overflow. Added smooth scroll to targets. [#310](https://github.com/LuxDL/DocumenterVitepress.jl/pull/310).

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DocumenterVitepress"
 uuid = "4710194d-e776-4893-9690-8d956a29c365"
 authors = ["Lazaro Alonso <lazarus.alon@gmail.com>", "Anshul Singhvi <anshulsinghvi@gmail.com>", "Julius Krumbiegel"]
-version = "0.2.8"
+version = "0.3.0"
 
 [deps]
 ANSIColoredPrinters = "a4c015fc-c6ff-483c-b24f-f7ea428134e9"


### PR DESCRIPTION
I’m bumping this to a breaking version to ensure that all **0.2** patches remain independent from the introduction of the new math plugin rendering, see [some examples](https://luxdl.github.io/DocumenterVitepress.jl/dev/manual/markdown-examples#Multi-line-align-with-labeled-lines).

## No action required
This version automatically copies

- `mathjax-plugin.ts` to `.vitepress`

**if users are not using custom configurations**
- `config.mts`, `index.ts`  and `styles.css` files will be copied from the template, they have all updates.

## ACTION REQUIRED 
This version automatically copies

- `mathjax-plugin.ts` to `.vitepress`

**users are using custom configurations**
- `config.mts`
- `index.ts`
- `styles.css`

then they should add the following:

```ts
// config.mts
import { mathjaxPlugin } from './mathjax-plugin'
const mathjax = mathjaxPlugin()

export default defineConfig({
  markdown: {
      config(md) {
        mathjax.markdownConfig(md);
      },
    },
    vite: {
      plugins: [
        mathjax.vitePlugin,
      ],
  }
)
```

```ts
//index.ts
import 'virtual:mathjax-styles.css';
```
```css
/* style.css */
.mjx-scroll-wrapper {
  display: block;
  max-width: 100%;
  overflow-x: auto;
  overflow-y: hidden;
  text-align: center;
}

mjx-container {
  display: inline-block;
  padding: 0.5rem 0;
  margin: auto 2px -2px;
  overflow: visible !important;  /* Override MathJax's overflow */
  text-align: left;
}

mjx-container > svg {
  display: inline-block;
  height: auto;
}

mjx-container > svg[data-labels="true"] {
  position: absolute;
  left: 0;
  top: 0;
  width: 100%;
  height: 100%;
  pointer-events: none;
}

/* @mdit/plugin-mathjax theming refs */

mjx-container svg path {
  fill: currentColor !important;
  stroke: currentColor !important;
}

.MathJax_ref {
  color: var(--vp-c-brand-1);
}

.MathJax_ref:hover {
  color: var(--vp-c-brand-2);
  cursor: pointer;
}
```

@jkrumbiegel @asinghvi17 