### PR TITLE
built-in function

### DIFF
--- a/template/src/.vitepress/mathjax-plugin.ts
+++ b/template/src/.vitepress/mathjax-plugin.ts
@@ -42,27 +42,7 @@ async function initializeMathJax(options: MathJaxOptions = {}) {
   }
 
   await MathJax.init(config)
-
-  const fontData = MathJax.config.svg?.fontData
-
-  if (fontData?.dynamicFiles) {
-    const dynamicFiles = fontData.dynamicFiles
-    const dynamicPrefix: string =
-      fontData.OPTIONS?.dynamicPrefix || fontData.options?.dynamicPrefix
-
-    if (dynamicPrefix) {
-      await Promise.all(
-        Object.keys(dynamicFiles).map(async (name) => {
-          try {
-            await import(/* @vite-ignore */ `${dynamicPrefix}/${name}.js`)
-            dynamicFiles[name]?.setup?.(MathJax.startup.output.font)
-          } catch {
-            // Silently ignore missing dynamic files
-          }
-        }),
-      )
-    }
-  }
+  await MathJax.startup.document.outputJax.font.loadDynamicFiles()
 }
 
 export function mathjaxPlugin(options: MathJaxOptions = {}) {


### PR DESCRIPTION
I noticed this horrible (random?) [failure](https://buildkite.com/clima/oceananigans/builds/29529/steps/canvas?jid=019c789e-1b61-4586-9c24-a57079726463&tab=output#019c789e-1b61-4586-9c24-a57079726463/L3919). 

Let's try to use the [oficial API](https://docs.mathjax.org/en/latest/server/preload.html#loading-all-font-data-synchronously) instead of tree-path-walking assets.