### PR TITLE
fix: Only escape `<` and `>` in plain markdown text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## unreleased
+- Stopped HTML-escaping plain text in the emitted markdown beyond what is required to keep Vue from parsing `<`/`>` as HTML tags. Previously, characters like `&`, `'`, `"` were turned into entities, which surfaced as literal `&amp;` / `&#39;` / `&quot;` in browser tab titles (e.g. a heading `# PDF & SVG` showed as "PDF &amp; SVG") [#351](https://github.com/LuxDL/DocumenterVitepress.jl/pull/351)
 
 ## v0.3.3 - 2026-04-10
 - Fixed Windows paths for `Documenter`-crosslinks (`Documenter.PageLink` and `Documenter.LocalLink`) and for the nav/sidebar (via `pagelist2str`) [#340](https://github.com/LuxDL/DocumenterVitepress.jl/pull/340)

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -977,9 +977,14 @@ function autowrap_eqref(text::AbstractString)
     replace(text, EQREF_REGEX => m -> "\$$(m)\$")
 end
 
+# Only escape `<` and `>` here (Vue would otherwise parse them as HTML tags, see #101).
+# We deliberately do not escape `&`: vitepress copies the markdown title verbatim into
+# the per-page JSON used to set `document.title` on hydration, so an escaped `&amp;`
+# would surface as the literal 5-char string in the browser tab.
+escape_markdown_text(text::AbstractString) = replace(text, '<' => "&lt;", '>' => "&gt;")
+
 function render(io::IO, mime::MIME"text/plain", node::Documenter.MarkdownAST.Node, text::MarkdownAST.Text, page, doc; kwargs...)
-    wrapped = autowrap_eqref(text.text)
-    print(io, escapehtml(wrapped))
+    print(io, escape_markdown_text(autowrap_eqref(text.text)))
 end
 # Heading
 function render(io::IO, mime::MIME"text/plain", node::Documenter.MarkdownAST.Node, text::MarkdownAST.Heading, page, doc; kwargs...)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,2 +1,3 @@
 [deps]
+DocumenterVitepress = "4710194d-e776-4893-9690-8d956a29c365"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -89,3 +89,67 @@ end
         @test occursin("""var DOCUMENTER_STABLE = "stable";""", versions_js)
     end
 end
+
+@testset "escape_markdown_text" begin
+    esc = DocumenterVitepress.escape_markdown_text
+    # Characters that don't need escaping: HTML entities in the markdown source
+    # propagate through vitepress into the page-data JSON used to set document.title,
+    # surfacing as literal `&amp;` / `&#39;` / `&quot;` in browser tab titles.
+    @test esc("PDF & SVG") == "PDF & SVG"
+    @test esc("it's") == "it's"
+    @test esc("he said \"hi\"") == "he said \"hi\""
+    # `<` and `>` must still be escaped, otherwise Vue parses them as HTML tags (#101).
+    @test esc("a <cond> b") == "a &lt;cond&gt; b"
+    @test esc("plain text") == "plain text"
+end
+
+@testset "heading escaping (full vitepress round-trip)" begin
+    mktempdir() do dir
+        dir = realpath(dir)
+        src = joinpath(dir, "src")
+        mkpath(src)
+        write(joinpath(src, "index.md"), "# PDF & SVG\n\nbody with <cond> in it.\n")
+        # DocumenterVitepress shells out to `git tag` to determine version aliases;
+        # make `dir` a git repo so that succeeds (empty repo => no tags is fine).
+        run(pipeline(`$(Documenter.git()) -C $dir init --quiet`, stdout=devnull))
+
+        Documenter.makedocs(;
+            sitename = "Test",
+            root = dir,
+            source = "src",
+            build = "build",
+            warnonly = true,
+            remotes = nothing,
+            format = DocumenterVitepress.MarkdownVitepress(
+                repo = "github.com/test/Test.jl",
+                devbranch = "main",
+                devurl = "dev",
+                deploy_decision = Documenter.DeployDecision(; all_ok = false),
+            ),
+            pages = ["index.md"],
+        )
+
+        rendered_md = read(joinpath(dir, "build", ".documenter", "index.md"), String)
+        @test occursin("# PDF & SVG", rendered_md)
+        @test occursin("&lt;cond&gt;", rendered_md)
+
+        # The browser-tab title comes from two places, and the bug only manifests in one:
+        #   1. The static `<title>` in the HTML head — vitepress HTML-escapes the title
+        #      text here, so a bare `&` becomes `&amp;` and renders correctly as `&`.
+        #   2. The page-data JSON embedded in `assets/index.md.*.js`, used by the
+        #      client to call `document.title = data.title` after hydration. Vitepress
+        #      writes the markdown title text verbatim into this JSON — so if the
+        #      markdown source held the entity-encoded form `PDF &amp; SVG`, the JSON
+        #      gets the literal 13-char string `"PDF &amp; SVG"` and the tab ends up
+        #      showing "PDF &amp; SVG" once JS runs.
+        assets_dir = joinpath(dir, "build", "1", "assets")
+        page_data_js = only(filter(
+            f -> startswith(f, "index.md.") && endswith(f, ".js") && !endswith(f, ".lean.js"),
+            readdir(assets_dir),
+        ))
+        page_data = read(joinpath(assets_dir, page_data_js), String)
+        json_title = match(r"\\\"title\\\":\\\"(.*?)\\\"", page_data)
+        @test json_title !== nothing
+        @test json_title.captures[1] == "PDF & SVG"
+    end
+end


### PR DESCRIPTION
Plain text in headings (and elsewhere) was being run through Documenter's `escapehtml`, which turns `&`, `'`, `"`, `<`, `>` into HTML entities in the emitted markdown. Vitepress's static `<title>` tag survives that (the browser decodes the entity once), but vitepress also ships the markdown title verbatim into per-page JSON in `assets/index.md.*.js` which the client uses to set `document.title` on hydration. The entity stays a literal string there, so e.g. a heading `# PDF & SVG` ends up showing "PDF &amp; SVG" in the browser tab once JS runs (and the same for `'` → `&#39;`, `"` → `&quot;`).

Narrowed the escaping to just `<` and `>`, which is what [#106](https://github.com/LuxDL/DocumenterVitepress.jl/pull/106) was originally about (Vue parses them as HTML tags). Added a round-trip test that runs vitepress on a tiny doc and checks the title in the emitted page-data JS bundle, plus a small unit test for the helper.
