### PR TITLE
Flexible, overloadable sidebar/navbar rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- Made sidebar/navbar generation overloadable: `pagelist2str` now dispatches on a `Val{:sidebar}`/`Val{:navbar}` tag (with a `get_title` helper), so a custom `make.jl` can control how pages map to VitePress nav entries [#357](https://github.com/LuxDL/DocumenterVitepress.jl/pull/357)
 - Added `Documenter.Plugin` extension hooks (`vitepress_dependencies`, `vitepress_components`, `vitepress_config_transform`, `vitepress_assets`) for plugins to inject npm deps, Vue components, `config.mts` transforms, and `public/` assets at build time; all default to no-ops [#363](https://github.com/LuxDL/DocumenterVitepress.jl/pull/363)
 - `npm install` failures now surface the captured npm stderr/stdout via `@error` instead of a bare `ProcessExited` [#362](https://github.com/LuxDL/DocumenterVitepress.jl/pull/362)
 - Added a frontmatter stage that merges multiple `@frontmatter`/raw blocks into the single block VitePress allows, emits page `title` and meta `description`, and escapes them for YAML [#358](https://github.com/LuxDL/DocumenterVitepress.jl/pull/358)

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,6 +4,45 @@ using DocumenterCitations
 using DocumenterInterLinks
 using LaTeXStrings
 
+struct DecomposeInSidebar
+    path::String
+    pages::Any
+end
+
+# So you can only really pull this trick once in a Julia session
+# But because doc.user.pages is a Vector{Any}, we can't really do anything about it.
+function DocumenterVitepress.pagelist2str(doc, ds::Vector{<: Any}, ::Val{:sidebar})
+    println("Hello World!!!")
+    if !all(x -> x isa DecomposeInSidebar, ds)
+        # if this is false, invoke the default method.
+        return invoke(pagelist2str, Tuple{Any, Any, Val{:sidebar}}, doc, ds, Val(:sidebar))
+    end
+    contents = DocumenterVitepress.pagelist2str.((doc,), ds, (Val(:sidebar),))
+    ret = "{\n" * join(contents, ",\n") * "\n}"
+    println(ret)
+    return ret
+end
+
+function DocumenterVitepress.pagelist2str(doc, ds::DecomposeInSidebar, ::Val{:sidebar})
+    raw_contents = DocumenterVitepress.pagelist2str(doc, ds.pages, Val(:sidebar))
+    contents = if raw_contents isa String
+        raw_contents
+    else
+        join(raw_contents, ",\n")
+    end
+
+    return "\"/$(ds.path)/\": {\n$(contents)\n}"
+end
+
+function DocumenterVitepress.pagelist2str(doc, ds::DecomposeInSidebar, ::Val{:navbar})
+    return DocumenterVitepress.pagelist2str(doc, ds.pages, Val(:sidebar))
+end
+
+function Documenter.walk_navpages(ds::DecomposeInSidebar, parent, doc)
+    return Documenter.walk_navpages(ds.pages, parent, doc)
+end
+
+
 # Handle DocumenterCitations integration - if you're running this, then you don't need anything here!!
 documenter_citations_dir = dirname(dirname(pathof(DocumenterCitations)))
 documenter_citations_docs_dir = joinpath(documenter_citations_dir, "docs")
@@ -54,7 +93,7 @@ makedocs(;
     source = "src",
     build = "build",
     pages = [
-        "Manual" => [
+        DecomposeInSidebar("manual", "Manual" => [
             "Get Started" => "manual/get_started.md",
             "Updating to DocumenterVitepress" => "manual/documenter_to_vitepress_docs_example.md",
             "Code" => "manual/code_example.md",
@@ -65,12 +104,11 @@ makedocs(;
             "CSS Styling" => "manual/style_css.md",
             "Authors' badge" => "manual/author_badge.md",
             "GitHub Icon with Stars" => "manual/repo_stars.md",
-        ],
-        "Developers' documentation" => [
+        ]),
+        DecomposeInSidebar("devs", "Developers' documentation" => [
             "The rendering process" => "devs/render_pipeline.md",
             "Internal API" => "devs/internal_api.md",
-        ],
-        "api.md",
+        ]),
     ],
     plugins = [bib, links],
 )

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -12,14 +12,12 @@ end
 # So you can only really pull this trick once in a Julia session
 # But because doc.user.pages is a Vector{Any}, we can't really do anything about it.
 function DocumenterVitepress.pagelist2str(doc, ds::Vector{<: Any}, ::Val{:sidebar})
-    println("Hello World!!!")
     if !all(x -> x isa DecomposeInSidebar, ds)
         # if this is false, invoke the default method.
         return invoke(pagelist2str, Tuple{Any, Any, Val{:sidebar}}, doc, ds, Val(:sidebar))
     end
     contents = DocumenterVitepress.pagelist2str.((doc,), ds, (Val(:sidebar),))
     ret = "{\n" * join(contents, ",\n") * "\n}"
-    println(ret)
     return ret
 end
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,11 +9,9 @@ struct DecomposeInSidebar
     pages::Any
 end
 
-# So you can only really pull this trick once in a Julia session
-# But because doc.user.pages is a Vector{Any}, we can't really do anything about it.
+# NOTE: overrides pagelist2str globally; works once per Julia session.
 function DocumenterVitepress.pagelist2str(doc, ds::Vector{<: Any}, ::Val{:sidebar})
     if !all(x -> x isa DecomposeInSidebar, ds)
-        # if this is false, invoke the default method.
         return invoke(pagelist2str, Tuple{Any, Any, Val{:sidebar}}, doc, ds, Val(:sidebar))
     end
     contents = DocumenterVitepress.pagelist2str.((doc,), ds, (Val(:sidebar),))

--- a/src/vitepress_config.jl
+++ b/src/vitepress_config.jl
@@ -312,13 +312,24 @@ function pagelist2str(doc, page::AbstractString, sidenav::Val)
     path = replace(splitext(page)[1], "\\" => "/") # Handle Windows paths.
     return "text: '$(replace(name, "'" => "\\'"))', link: '/$(path)'" # , $(sidebar_items(doc, page)) }"
 end
+
+function pagelist2str(doc, name_page::Pair{<: Any, <: Any}, sidenav::Val)
+    name, page = name_page
+    # This is the simplest and easiest case.
+    return pagelist2str(doc, name => page, sidenav) # , $(sidebar_items(doc, page)) }"
+end
+
+function pagelist2str(doc, name_page::Pair{<: Any, <: Nothing}, sidenav::Val)
+    return ""
+end
+
 function pagelist2str(doc, name_page::Pair{<: AbstractString, <: AbstractString}, sidenav::Val)
     name, page = name_page
     # This is the simplest and easiest case.
     path = replace(splitext(page)[1], "\\" => "/") # Handle Windows paths.
     return "text: '$(replace(name, "'" => "\\'"))', link: '/$(path)'" # , $(sidebar_items(doc, page)) }"
 end
-function pagelist2str(doc, name_contents::Pair{<: AbstractString, <: AbstractVector}, sidenav::Val)
+function pagelist2str(doc, name_contents::Pair{<: AbstractString, <: AbstractArray}, sidenav::Val)
     name, contents = name_contents
     # This is for nested stuff.  Should work automatically but you never know...
     rendered_contents = map(contents) do content

--- a/src/vitepress_config.jl
+++ b/src/vitepress_config.jl
@@ -300,26 +300,25 @@ function get_title(doc, page::AbstractString)
 end
 get_title(doc, page::Pair{<: AbstractString, <: Any}) = first(page)
 
-# Catch all method: just broadcast over any iterable assuming it is a collection
+# Catch-all: treat any other iterable as a collection of page entries.
 function pagelist2str(doc, pages, sidenav::Val)
     contents = String[]
     for page in pages
         str = pagelist2str(doc, page, sidenav)
-        isempty(str) || push!(contents, "{ " * str * " }")  # skip omitted/hidden (`nothing`) pages
+        isempty(str) || push!(contents, "{ " * str * " }")
     end
     return "[" * join(contents, ",\n") * "]"
 end
 function pagelist2str(doc, page::AbstractString, sidenav::Val)
     name = get_title(doc, page)
     path = replace(splitext(page)[1], "\\" => "/") # Handle Windows paths.
-    return "text: '$(replace(name, "'" => "\\'"))', link: '/$(path)'" # , $(sidebar_items(doc, page)) }"
+    return "text: '$(replace(name, "'" => "\\'"))', link: '/$(path)'"
 end
 
 function pagelist2str(doc, name_page::Pair{<: Any, <: Any}, sidenav::Val)
     name, page = name_page
-    # Normalize the name to a `String` so the pair dispatches to a concrete method
-    # above. If that doesn't change the pair's type (an unsupported `page` type),
-    # error instead of recursing into this same method forever.
+    # Normalize name to String so the pair hits a concrete method; error (don't
+    # recurse forever) if the type is unchanged, i.e. an unsupported page type.
     new_pair = string(name) => page
     typeof(new_pair) === typeof(name_page) &&
         error("DocumenterVitepress: unsupported `pages` entry $(repr(name_page)) of type $(typeof(name_page)).")
@@ -332,17 +331,16 @@ end
 
 function pagelist2str(doc, name_page::Pair{<: AbstractString, <: AbstractString}, sidenav::Val)
     name, page = name_page
-    # This is the simplest and easiest case.
     path = replace(splitext(page)[1], "\\" => "/") # Handle Windows paths.
-    return "text: '$(replace(name, "'" => "\\'"))', link: '/$(path)'" # , $(sidebar_items(doc, page)) }"
+    return "text: '$(replace(name, "'" => "\\'"))', link: '/$(path)'"
 end
 function pagelist2str(doc, name_contents::Pair{<: AbstractString, <: AbstractArray}, sidenav::Val)
     name, contents = name_contents
-    # This is for nested stuff.  Should work automatically but you never know...
+    # Nested section: a name => array of child page entries.
     rendered_contents = String[]
     for content in contents
         str = pagelist2str(doc, content, sidenav)
-        isempty(str) || push!(rendered_contents, "{" * str * "}")  # skip omitted/hidden (`nothing`) pages
+        isempty(str) || push!(rendered_contents, "{" * str * "}")
     end
     final_contents = join(rendered_contents, ",\n")
     collapse = if sidenav === Val(:sidebar)

--- a/src/vitepress_config.jl
+++ b/src/vitepress_config.jl
@@ -302,8 +302,10 @@ get_title(doc, page::Pair{<: AbstractString, <: Any}) = first(page)
 
 # Catch all method: just broadcast over any iterable assuming it is a collection
 function pagelist2str(doc, pages, sidenav::Val)
-    contents = map(pages) do page
-        "{ " * pagelist2str(doc, page, sidenav) * " }"
+    contents = String[]
+    for page in pages
+        str = pagelist2str(doc, page, sidenav)
+        isempty(str) || push!(contents, "{ " * str * " }")  # skip omitted/hidden (`nothing`) pages
     end
     return "[" * join(contents, ",\n") * "]"
 end
@@ -315,8 +317,13 @@ end
 
 function pagelist2str(doc, name_page::Pair{<: Any, <: Any}, sidenav::Val)
     name, page = name_page
-    # This is the simplest and easiest case.
-    return pagelist2str(doc, name => page, sidenav) # , $(sidebar_items(doc, page)) }"
+    # Normalize the name to a `String` so the pair dispatches to a concrete method
+    # above. If that doesn't change the pair's type (an unsupported `page` type),
+    # error instead of recursing into this same method forever.
+    new_pair = string(name) => page
+    typeof(new_pair) === typeof(name_page) &&
+        error("DocumenterVitepress: unsupported `pages` entry $(repr(name_page)) of type $(typeof(name_page)).")
+    return pagelist2str(doc, new_pair, sidenav)
 end
 
 function pagelist2str(doc, name_page::Pair{<: Any, <: Nothing}, sidenav::Val)
@@ -332,8 +339,10 @@ end
 function pagelist2str(doc, name_contents::Pair{<: AbstractString, <: AbstractArray}, sidenav::Val)
     name, contents = name_contents
     # This is for nested stuff.  Should work automatically but you never know...
-    rendered_contents = map(contents) do content
-        "{" * pagelist2str(doc, content, sidenav) * "}"
+    rendered_contents = String[]
+    for content in contents
+        str = pagelist2str(doc, content, sidenav)
+        isempty(str) || push!(rendered_contents, "{" * str * "}")  # skip omitted/hidden (`nothing`) pages
     end
     final_contents = join(rendered_contents, ",\n")
     collapse = if sidenav === Val(:sidebar)

--- a/src/vitepress_config.jl
+++ b/src/vitepress_config.jl
@@ -123,10 +123,10 @@ function modify_config_file(doc, settings, deploy_decision, i_folder, base)
     # # Vitepress navbar and sidebar
 
     provided_page_list = doc.user.pages
-    sidebar_navbar_info = pagelist2str.((doc,), provided_page_list)
-    sidebar_navbar_string = join(sidebar_navbar_info, ",\n")
-    push!(replacers, "sidebar: 'REPLACE_ME_DOCUMENTER_VITEPRESS'" => "sidebar: [\n$sidebar_navbar_string\n]\n")
-    push!(replacers, "nav: 'REPLACE_ME_DOCUMENTER_VITEPRESS'" => "nav: [\n$sidebar_navbar_string\n]\n")
+    sidebar_info = sprint(print, pagelist2str(doc, provided_page_list, Val(:sidebar)))
+    navbar_info = sprint(print, pagelist2str(doc, provided_page_list, Val(:navbar)))
+    push!(replacers, "sidebar: 'REPLACE_ME_DOCUMENTER_VITEPRESS'" => "sidebar: $(sidebar_info)\n")
+    push!(replacers, "nav: 'REPLACE_ME_DOCUMENTER_VITEPRESS'" => "nav: $(navbar_info)\n")
 
     # # Title
     push!(replacers, "title: 'REPLACE_ME_DOCUMENTER_VITEPRESS'" => "title: '$(doc.user.sitename)'")
@@ -191,8 +191,7 @@ function modify_config_file(doc, settings, deploy_decision, i_folder, base)
     return
 end
 
-function _get_raw_text(element)
-end
+# Utility methods to get data about pages
 
 """
     apply_noindex(config::AbstractString, noindex_non_stable::Bool, base::AbstractString) -> String
@@ -284,7 +283,7 @@ function inject_plugin_components!(theme_index_path::String, doc)
     return
 end
 
-function pagelist2str(doc, page::String)
+function get_title(doc, page::AbstractString)
     # If no name is given, find the first header in the page,
     # and use that as the name.
     elements = collect(doc.blueprint.pages[page].mdast.children)
@@ -297,37 +296,36 @@ function pagelist2str(doc, page::String)
     else
         Documenter.MDFlatten.mdflatten(elements[idx])
     end
-    path = replace(splitext(page)[1], "\\" => "/") # Handle Windows paths.
-    return "{ text: '$(replace(name, "'" => "\\'"))', link: '/$(path)' }" # , $(sidebar_items(doc, page)) }"
+    return name
 end
+get_title(doc, page::Pair{<: AbstractString, <: Any}) = first(page)
 
-pagelist2str(doc, name_any::Pair{String, <: Any}) = pagelist2str(doc, first(name_any) => last(name_any))
-
-function pagelist2str(doc, name_page::Pair{String, String})
+# Catch all method: just broadcast over any iterable assuming it is a collection
+function pagelist2str(doc, pages, sidenav::Val)
+    contents = map(pages) do page
+        "{ " * pagelist2str(doc, page, sidenav) * " }"
+    end
+    return "[" * join(contents, ",\n") * "]"
+end
+function pagelist2str(doc, page::AbstractString, sidenav::Val)
+    name = get_title(doc, page)
+    path = replace(splitext(page)[1], "\\" => "/") # Handle Windows paths.
+    return "text: '$(replace(name, "'" => "\\'"))', link: '/$(path)'" # , $(sidebar_items(doc, page)) }"
+end
+function pagelist2str(doc, name_page::Pair{<: AbstractString, <: AbstractString}, sidenav::Val)
     name, page = name_page
     # This is the simplest and easiest case.
     path = replace(splitext(page)[1], "\\" => "/") # Handle Windows paths.
-    return "{ text: '$(replace(name, "'" => "\\'"))', link: '/$(path)' }" # , $(sidebar_items(doc, page)) }"
+    return "text: '$(replace(name, "'" => "\\'"))', link: '/$(path)'" # , $(sidebar_items(doc, page)) }"
 end
-
-function pagelist2str(doc, name_contents::Pair{String, <: AbstractVector})
+function pagelist2str(doc, name_contents::Pair{<: AbstractString, <: AbstractVector}, sidenav::Val)
     name, contents = name_contents
     # This is for nested stuff.  Should work automatically but you never know...
-    rendered_contents = pagelist2str.((doc,), contents)
-    return "{ text: '$(replace(name, "'" => "\\'"))', collapsed: false, items: [\n$(join(rendered_contents, ",\n"))]\n }" # TODO: add a link here if the name is the same name as a file?
-end
-
-function sidebar_items(doc, page::String)
-    # We look at the page elements, and obtain all level 1 and 2 headers.
-    elements = doc.blueprint.pages[page].elements
-    headers = filter(x -> x isa Union{MarkdownAST.Heading{1}, MarkdownAST.Heading{2}}, elements)
-    # If nothing is found, move on in life
-    if length(headers) ≤ 1
-        return ""
+    rendered_contents = map(contents) do content
+        "{" * pagelist2str(doc, content, sidenav) * "}"
     end
-    # Otherwise, we return a collapsible tree of headers for each level 1 and 2 header.
-    items = headers
-    return "collapsed: true, items: [\n $(join(_item_link.((page,), items), ",\n"))\n]"
+    final_contents = join(rendered_contents, ",\n")
+    return "text: '$(replace(name, "'" => "\\'"))', collapsed: false, items: [\n$(final_contents)\n]" # TODO: add a link here if the name is the same name as a file?
 end
 
 function _item_link(page, item)

--- a/src/vitepress_config.jl
+++ b/src/vitepress_config.jl
@@ -336,7 +336,12 @@ function pagelist2str(doc, name_contents::Pair{<: AbstractString, <: AbstractArr
         "{" * pagelist2str(doc, content, sidenav) * "}"
     end
     final_contents = join(rendered_contents, ",\n")
-    return "text: '$(replace(name, "'" => "\\'"))', collapsed: false, items: [\n$(final_contents)\n]" # TODO: add a link here if the name is the same name as a file?
+    collapse = if sidenav === Val(:sidebar)
+        "collapsed: false,"
+    else
+        ""
+    end
+    return "text: '$(replace(name, "'" => "\\'"))', $collapse items: [\n$(final_contents)\n]" # TODO: add a link here if the name is the same name as a file?
 end
 
 function _item_link(page, item)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -278,3 +278,22 @@ end
         @test read(joinpath(public, "top.txt"), String) == "from-b"
     end
 end
+
+@testset "pagelist2str dispatch" begin
+    # `Pair`-based entries don't touch `doc`, so a dummy `nothing` is enough here.
+    p2s(arg) = DocumenterVitepress.pagelist2str(nothing, arg, Val(:sidebar))
+    # leaf pair
+    @test occursin("text: 'Home'", p2s("Home" => "index.md"))
+    # a non-String name routes through the `Any => Any` fallback without recursing forever
+    @test occursin("text: 'sym'", p2s(:sym => "page.md"))
+    # a `nothing` page is omitted
+    @test p2s("Hidden" => nothing) == ""
+    # a genuinely unsupported page type errors instead of infinitely recursing
+    @test_throws ErrorException p2s("bad" => 123)
+    # nested arrays drop omitted children — no `{}` junk
+    nested = p2s("Sec" => ["A" => "a.md", "Skip" => nothing])
+    @test occursin("text: 'A'", nested)
+    @test !occursin("{}", nested)
+    # collection level filters empties too — no `{  }` junk
+    @test !occursin("{  }", p2s(["A" => "a.md", "Skip" => nothing]))
+end


### PR DESCRIPTION
Extracted from the `as/plugin-extension-hooks` stack (originally bundled into #278), rebased onto `main` as a standalone change. One of several orthogonal PRs split out of that stack.

## What

Refactors `pagelist2str` so sidebar and navbar generation dispatch on a `Val{:sidebar}` / `Val{:navbar}` tag, and splits page-title lookup into its own `get_title` method. This makes nav emission **overloadable**: a downstream `make.jl` can add `pagelist2str` methods to customize how pages map to VitePress nav entries (e.g. per-section sidebars) instead of the previous hard-coded single shape.

- `src/vitepress_config.jl`: a `pagelist2str(doc, pages, ::Val)` dispatch family + `get_title`; the sidebar variant emits `collapsed: false`, the navbar variant omits it.
- `docs/make.jl`: dogfoods the hook with a small `DecomposeInSidebar` example giving the manual and devs sections their own sidebars.

## Notes
- Dropped two leftover debug `println`s from the `make.jl` demo during extraction.
- Test suite (incl. the full VitePress round-trip test) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
