### PR TITLE
Frontmatter pipeline: merge blocks, emit title/description, escape YAML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## unreleased
+- Added a frontmatter stage that merges multiple `@frontmatter`/raw blocks into the single block VitePress allows, emits page `title` and meta `description`, and escapes them for YAML [#358](https://github.com/LuxDL/DocumenterVitepress.jl/pull/358)
 - Interactive `text/html` show output that contains `<script>` tags (e.g. WGLMakie/Bonito figures, Plotly) now actually runs. Such output is wrapped in `<ClientOnly>` (so the potentially-multi-MB widget is not server-rendered) and its scripts are executed on the client via a new `v-exec-scripts` directive, on the initial render and on client-side navigation — previously `v-html` set `innerHTML`, whose `<script>` tags the browser never executes, so figures only appeared on a hard reload. Script-free HTML output keeps the plain server-rendered `v-html` path.
 - Added a GitHub Actions workflow for posting a PR preview comment with a link to the documentation preview. The workflow automatically reads `deploy_repo` from `docs/make.jl` to support cross-repository deployments, and only runs on PRs from the same repository (not forks) [#355](https://github.com/LuxDL/DocumenterVitepress.jl/pull/355)
 

--- a/src/DocumenterVitepress.jl
+++ b/src/DocumenterVitepress.jl
@@ -15,6 +15,7 @@ const ASSETS = normpath(joinpath(@__DIR__, "..", "assets"))
 
 include("vitepress_interface.jl")
 include("vitepress_config.jl")
+include("frontmatter.jl")
 include("writer.jl")
 include("ANSIBlocks.jl")
 

--- a/src/frontmatter.jl
+++ b/src/frontmatter.jl
@@ -13,6 +13,13 @@ function merge_and_render_frontmatter(io::IO, mime::MIME"text/yaml", page, doc; 
             push!(frontmatter, join(split(element.text, "\n")[2:end-1], "\n"))
         end
     end
+
+    if haskey(page.globals.meta, :Title)
+        pushfirst!(frontmatter, "title: \"$(page.globals.meta[:Title])\"")
+    end
+    if haskey(page.globals.meta, :Description)
+        pushfirst!(frontmatter, "description: \"$(page.globals.meta[:Description])\"")
+    end
     println(io, "---")
     println(io, join(frontmatter, "\n"))
     println(io, "---")

--- a/src/frontmatter.jl
+++ b/src/frontmatter.jl
@@ -1,0 +1,19 @@
+# In Vitepress you can only have one frontmatter block.
+# But users / other Documenter stages may inject multiple.
+# So, we have a stage that will merge and render all frontmatter blocks
+# before doing anything else.
+
+function merge_and_render_frontmatter(io::IO, mime::MIME"text/yaml", page, doc; kwargs...)
+    frontmatter = String[]
+    for block in page.mdast.children
+        element = block.element
+        if element isa MarkdownAST.CodeBlock && element.info == "@frontmatter"
+            push!(frontmatter, element.code)
+        elseif element isa Documenter.RawNode && startswith(element.text, "---")
+            push!(frontmatter, join(split(element.text, "\n")[2:end-1], "\n"))
+        end
+    end
+    println(io, "---")
+    println(io, join(frontmatter, "\n"))
+    println(io, "---")
+end

--- a/src/frontmatter.jl
+++ b/src/frontmatter.jl
@@ -1,7 +1,5 @@
-# In Vitepress you can only have one frontmatter block.
-# But users / other Documenter stages may inject multiple.
-# So, we have a stage that will merge and render all frontmatter blocks
-# before doing anything else.
+# Vitepress allows only one frontmatter block, but users / Documenter stages may
+# inject several, so this stage merges them into one.
 
 """
     _escape_yaml_double_quoted(value) -> String
@@ -33,10 +31,8 @@ end
 """
     _strip_frontmatter_delimiters(text) -> String
 
-Return the inner YAML of a raw `---\\n…\\n---` frontmatter block, dropping the
-opening/closing `---` and any surrounding whitespace. Robust to a trailing
-newline (a plain `split(text, "\\n")[2:end-1]` would leave the closing `---` in
-place when the block ends with one).
+Inner YAML of a `---…---` block, robust to a trailing newline that a plain
+`split[2:end-1]` would mishandle (leaving the closing `---`).
 """
 function _strip_frontmatter_delimiters(text::AbstractString)
     cleaned = strip(text)
@@ -46,8 +42,7 @@ function _strip_frontmatter_delimiters(text::AbstractString)
 end
 
 function merge_and_render_frontmatter(io::IO, mime::MIME"text/yaml", page, doc; kwargs...)
-    # Print directly to `io`: one frontmatter block, meta first, then the page's
-    # own `@frontmatter` / raw blocks (which win on duplicate keys).
+    # One merged block; later (page) blocks win on duplicate keys.
     println(io, "---")
     if haskey(page.globals.meta, :Title)
         println(io, "title: \"$(_escape_yaml_double_quoted(page.globals.meta[:Title]))\"")

--- a/src/frontmatter.jl
+++ b/src/frontmatter.jl
@@ -6,12 +6,9 @@
 """
     _escape_yaml_double_quoted(value) -> String
 
-Escape `value` so it can be safely embedded inside a double-quoted YAML scalar
-(`key: "..."`). Page titles and descriptions set via `page.globals.meta` are
-arbitrary text; without escaping, an embedded `"` closes the scalar early and a
-raw newline turns it into a multi-line scalar, both of which produce invalid
-frontmatter and break the Vitepress build with errors such as
-`a multiline key may not be an implicit key`.
+Escape `value` for embedding in a double-quoted YAML scalar (`key: "..."`). Page
+titles/descriptions from `page.globals.meta` are arbitrary text; an unescaped `"`
+or newline would otherwise close the scalar early and break the frontmatter.
 """
 function _escape_yaml_double_quoted(value)
     io = IOBuffer()

--- a/src/frontmatter.jl
+++ b/src/frontmatter.jl
@@ -3,6 +3,36 @@
 # So, we have a stage that will merge and render all frontmatter blocks
 # before doing anything else.
 
+"""
+    _escape_yaml_double_quoted(value) -> String
+
+Escape `value` so it can be safely embedded inside a double-quoted YAML scalar
+(`key: "..."`). Page titles and descriptions set via `page.globals.meta` are
+arbitrary text; without escaping, an embedded `"` closes the scalar early and a
+raw newline turns it into a multi-line scalar, both of which produce invalid
+frontmatter and break the Vitepress build with errors such as
+`a multiline key may not be an implicit key`.
+"""
+function _escape_yaml_double_quoted(value)
+    io = IOBuffer()
+    for c in string(value)
+        if c == '\\'
+            print(io, "\\\\")
+        elseif c == '"'
+            print(io, "\\\"")
+        elseif c == '\n'
+            print(io, "\\n")
+        elseif c == '\r'
+            print(io, "\\r")
+        elseif c == '\t'
+            print(io, "\\t")
+        else
+            print(io, c)
+        end
+    end
+    return String(take!(io))
+end
+
 function merge_and_render_frontmatter(io::IO, mime::MIME"text/yaml", page, doc; kwargs...)
     frontmatter = String[]
     for block in page.mdast.children
@@ -15,10 +45,10 @@ function merge_and_render_frontmatter(io::IO, mime::MIME"text/yaml", page, doc; 
     end
 
     if haskey(page.globals.meta, :Title)
-        pushfirst!(frontmatter, "title: \"$(page.globals.meta[:Title])\"")
+        pushfirst!(frontmatter, "title: \"$(_escape_yaml_double_quoted(page.globals.meta[:Title]))\"")
     end
     if haskey(page.globals.meta, :Description)
-        pushfirst!(frontmatter, "description: \"$(page.globals.meta[:Description])\"")
+        pushfirst!(frontmatter, "description: \"$(_escape_yaml_double_quoted(page.globals.meta[:Description]))\"")
     end
     println(io, "---")
     println(io, join(frontmatter, "\n"))

--- a/src/frontmatter.jl
+++ b/src/frontmatter.jl
@@ -30,24 +30,38 @@ function _escape_yaml_double_quoted(value)
     return String(take!(io))
 end
 
+"""
+    _strip_frontmatter_delimiters(text) -> String
+
+Return the inner YAML of a raw `---\\n…\\n---` frontmatter block, dropping the
+opening/closing `---` and any surrounding whitespace. Robust to a trailing
+newline (a plain `split(text, "\\n")[2:end-1]` would leave the closing `---` in
+place when the block ends with one).
+"""
+function _strip_frontmatter_delimiters(text::AbstractString)
+    cleaned = strip(text)
+    head = startswith(cleaned, "---") ? 3 : 0
+    tail = endswith(cleaned, "---") ? 3 : 0
+    return strip(chop(cleaned; head, tail))
+end
+
 function merge_and_render_frontmatter(io::IO, mime::MIME"text/yaml", page, doc; kwargs...)
-    frontmatter = String[]
+    # Print directly to `io`: one frontmatter block, meta first, then the page's
+    # own `@frontmatter` / raw blocks (which win on duplicate keys).
+    println(io, "---")
+    if haskey(page.globals.meta, :Title)
+        println(io, "title: \"$(_escape_yaml_double_quoted(page.globals.meta[:Title]))\"")
+    end
+    if haskey(page.globals.meta, :Description)
+        println(io, "description: \"$(_escape_yaml_double_quoted(page.globals.meta[:Description]))\"")
+    end
     for block in page.mdast.children
         element = block.element
         if element isa MarkdownAST.CodeBlock && element.info == "@frontmatter"
-            push!(frontmatter, element.code)
+            println(io, rstrip(element.code))
         elseif element isa Documenter.RawNode && startswith(element.text, "---")
-            push!(frontmatter, join(split(element.text, "\n")[2:end-1], "\n"))
+            println(io, _strip_frontmatter_delimiters(element.text))
         end
     end
-
-    if haskey(page.globals.meta, :Title)
-        pushfirst!(frontmatter, "title: \"$(_escape_yaml_double_quoted(page.globals.meta[:Title]))\"")
-    end
-    if haskey(page.globals.meta, :Description)
-        pushfirst!(frontmatter, "description: \"$(_escape_yaml_double_quoted(page.globals.meta[:Description]))\"")
-    end
-    println(io, "---")
-    println(io, join(frontmatter, "\n"))
     println(io, "---")
 end

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -230,6 +230,7 @@ function render(doc::Documenter.Document, settings::MarkdownVitepress=MarkdownVi
     for (src, page) in doc.blueprint.pages
         # This is where you can operate on a per-page level.
         open(docpath(page.build, builddir, settings.md_output_path), "w") do io
+            merge_and_render_frontmatter(io, MIME("text/yaml"), page, doc)
             for node in page.mdast.children
                 render(io, mime, node, page, doc; inventory)
             end

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -973,6 +973,9 @@ render(io::IO, mime::MIME"text/plain", node::MarkdownAST.Node, ::Documenter.Setu
 # Raw nodes are used to insert raw HTML into the output. We just print it as is.
 # TODO: what if the `raw` is not HTML?  That is not addressed here but we ought to address it...
 function render(io::IO, ::MIME"text/plain", node::Documenter.MarkdownAST.Node, raw::Documenter.RawNode, page, doc; kwargs...)
+    if startswith(raw.text, "---")
+        return # this was already handled by frontmatter.
+    end
     return raw.name === :html ? println(io, raw.text, "\n") : nothing
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,26 @@ using DocumenterVitepress.Documenter
 using Test
 
 
+@testset "frontmatter YAML escaping" begin
+    esc = DocumenterVitepress._escape_yaml_double_quoted
+    # plain text is unchanged
+    @test esc("plain description") == "plain description"
+    # embedded double quotes are escaped (the SphericalPendulumConstraint regression:
+    # an unescaped `"` closed the YAML scalar early and broke the Vitepress build)
+    @test esc("Mirrors the \"Spherical joint\" test") == "Mirrors the \\\"Spherical joint\\\" test"
+    # newlines become escape sequences, never raw line breaks
+    @test esc("line one\nline two") == "line one\\nline two"
+    # backslashes are doubled
+    @test esc("a\\b") == "a\\\\b"
+    # tabs and carriage returns
+    @test esc("a\tb\rc") == "a\\tb\\rc"
+    # non-string values are accepted (page meta may hold any value)
+    @test esc(:sym) == "sym"
+    # the escaped value embedded in a `key: "..."` line stays on a single line
+    val = esc("Dyad docs.  Mirrors the \"Spherical joint without state\" test")
+    @test !occursin('\n', "description: \"$val\"")
+end
+
 @testset "Bases" begin
     determine_bases(args...; kwargs...) = DocumenterVitepress.determine_bases(args...; kwargs..., log = false)
     # 0.0.X

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,8 +7,7 @@ using Test
     esc = DocumenterVitepress._escape_yaml_double_quoted
     # plain text is unchanged
     @test esc("plain description") == "plain description"
-    # embedded double quotes are escaped (the SphericalPendulumConstraint regression:
-    # an unescaped `"` closed the YAML scalar early and broke the Vitepress build)
+    # double quotes escaped (the regression: an unescaped `"` broke the build)
     @test esc("Mirrors the \"Spherical joint\" test") == "Mirrors the \\\"Spherical joint\\\" test"
     # newlines become escape sequences, never raw line breaks
     @test esc("line one\nline two") == "line one\\nline two"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,6 +23,17 @@ using Test
     @test !occursin('\n', "description: \"$val\"")
 end
 
+@testset "frontmatter delimiter stripping" begin
+    strip_delims = DocumenterVitepress._strip_frontmatter_delimiters
+    # no trailing newline
+    @test strip_delims("---\ntitle: My Page\n---") == "title: My Page"
+    # trailing newline must not leave the closing `---` behind (the regression)
+    @test strip_delims("---\ntitle: My Page\n---\n") == "title: My Page"
+    @test !occursin("---", strip_delims("---\ntitle: My Page\n---\n"))
+    # multi-line body and surrounding whitespace
+    @test strip_delims("\n---\na: 1\nb: 2\n---\n\n") == "a: 1\nb: 2"
+end
+
 @testset "Bases" begin
     determine_bases(args...; kwargs...) = DocumenterVitepress.determine_bases(args...; kwargs..., log = false)
     # 0.0.X


### PR DESCRIPTION
Extracted from the `as/plugin-extension-hooks` stack (originally bundled into #278), rebased onto `main`. One of several orthogonal PRs split out of that stack.

## What
Adds a frontmatter-processing stage so VitePress gets a single, valid frontmatter block per page:

- **Merge + render** all `@frontmatter` blocks into one (`src/frontmatter.jl`, wired into the writer). VitePress allows only one frontmatter block, but users / Documenter stages may inject several.
- **Don't emit frontmatter inside raw nodes** (`writer.jl`).
- **Emit page `title` and meta `description`** from `page.globals.meta` into the frontmatter.
- **Escape title/description** before embedding them in the double-quoted YAML scalars — an unescaped `"` or newline previously closed the scalar early and broke the build (e.g. `a multiline key may not be an implicit key`). Covered by the new `frontmatter YAML escaping` testset.

## Notes
- Tightened the `_escape_yaml_double_quoted` docstring during extraction.
- Test suite (incl. the full VitePress round-trip) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
