### PR TITLE
Fix deploy-URL / base-path handling for custom domains and subpaths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased
 
 - Made sidebar/navbar generation overloadable: `pagelist2str` now dispatches on a `Val{:sidebar}`/`Val{:navbar}` tag (with a `get_title` helper), so a custom `make.jl` can control how pages map to VitePress nav entries [#357](https://github.com/LuxDL/DocumenterVitepress.jl/pull/357)
+- Fixed VitePress `base`-path derivation from `repo`/`deploy_url`: split on `/` instead of `splitpath` (which mangled URLs), support custom-domain subpaths, and strip trailing slashes [#359](https://github.com/LuxDL/DocumenterVitepress.jl/pull/359)
 - Added `Documenter.Plugin` extension hooks (`vitepress_dependencies`, `vitepress_components`, `vitepress_config_transform`, `vitepress_assets`) for plugins to inject npm deps, Vue components, `config.mts` transforms, and `public/` assets at build time; all default to no-ops [#363](https://github.com/LuxDL/DocumenterVitepress.jl/pull/363)
 - `npm install` failures now surface the captured npm stderr/stdout via `@error` instead of a bare `ProcessExited` [#362](https://github.com/LuxDL/DocumenterVitepress.jl/pull/362)
 - Added a frontmatter stage that merges multiple `@frontmatter`/raw blocks into the single block VitePress allows, emits page `title` and meta `description`, and escapes them for YAML [#358](https://github.com/LuxDL/DocumenterVitepress.jl/pull/358)

--- a/src/vitepress_config.jl
+++ b/src/vitepress_config.jl
@@ -106,13 +106,13 @@ function modify_config_file(doc, settings, deploy_decision, i_folder, base)
             @info "Base is \"\" and ENV[\"CI\"] is not set so this is a local build. Not adding any additional base prefix based on the repository or deploy url and instead using absolute path \"/\" to facilitate serving docs locally."
             "/"
         elseif isnothing(settings.deploy_url)
-            "/" * split(settings.repo, '/')[end]  # Get the last identifier of the repo path, i.e., `user/$repo`.
+            "/" * split(rstrip(settings.repo, '/'), '/')[end]  # Get the last identifier of the repo path, i.e., `user/$repo`.
         else
-            s_path = if startswith(settings.deploy_url, r"http[s?]:\/\/")
-                frags = split(settings.deploy_url, '/') # "https", "", "my.custom.domain", "sub", "dir"
+            s_path = if startswith(settings.deploy_url, r"^https?://")
+                frags = split(rstrip(settings.deploy_url, '/'), '/') # "https", "", "my.custom.domain", "sub", "dir"
                 length(frags) >= 4 ? frags[4:end] : [""] #                             |-> "sub", "dir"
             else
-                split(settings.deploy_url, '/') # "sub", "dir"
+                split(rstrip(settings.deploy_url, '/'), '/') # "sub", "dir"
             end
             s = join(s_path, '/')
             isempty(s) ? "/" : "/$(s)"

--- a/src/vitepress_config.jl
+++ b/src/vitepress_config.jl
@@ -110,11 +110,11 @@ function modify_config_file(doc, settings, deploy_decision, i_folder, base)
         else
             s_path = if startswith(settings.deploy_url, r"http[s?]:\/\/")
                 frags = split(settings.deploy_url, '/') # "https", "", "my.custom.domain", "sub", "dir"
-                length(frags) > 3 ? frags[3:end] : "/" #                               |-> "sub", "dir"
+                length(frags) >= 4 ? frags[4:end] : "/" #                               |-> "sub", "dir"
             else
                 split(settings.deploy_url, '/') # "sub", "dir"
             end
-            s = length(s_path) > 1 ? joinpath(s_path) : "" # ignore custom URL here
+            s = join(s_path, '/')
             isempty(s) ? "/" : "/$(s)"
         end
 

--- a/src/vitepress_config.jl
+++ b/src/vitepress_config.jl
@@ -106,9 +106,14 @@ function modify_config_file(doc, settings, deploy_decision, i_folder, base)
             @info "Base is \"\" and ENV[\"CI\"] is not set so this is a local build. Not adding any additional base prefix based on the repository or deploy url and instead using absolute path \"/\" to facilitate serving docs locally."
             "/"
         elseif isnothing(settings.deploy_url)
-            "/" * splitpath(settings.repo)[end]  # Get the last identifier of the repo path, i.e., `user/$repo`.
+            "/" * split(settings.repo, '/')[end]  # Get the last identifier of the repo path, i.e., `user/$repo`.
         else
-            s_path = startswith(settings.deploy_url, r"http[s?]:\/\/") ? splitpath(settings.deploy_url)[2:end] : splitpath(settings.deploy_url)
+            s_path = if startswith(settings.deploy_url, r"http[s?]:\/\/")
+                frags = split(settings.deploy_url, '/') # "https", "", "my.custom.domain", "sub", "dir"
+                length(frags) > 3 ? frags[3:end] : "/" #                               |-> "sub", "dir"
+            else
+                split(settings.deploy_url, '/') # "sub", "dir"
+            end
             s = length(s_path) > 1 ? joinpath(s_path) : "" # ignore custom URL here
             isempty(s) ? "/" : "/$(s)"
         end

--- a/src/vitepress_config.jl
+++ b/src/vitepress_config.jl
@@ -110,7 +110,7 @@ function modify_config_file(doc, settings, deploy_decision, i_folder, base)
         else
             s_path = if startswith(settings.deploy_url, r"http[s?]:\/\/")
                 frags = split(settings.deploy_url, '/') # "https", "", "my.custom.domain", "sub", "dir"
-                length(frags) >= 4 ? frags[4:end] : "/" #                               |-> "sub", "dir"
+                length(frags) >= 4 ? frags[4:end] : [""] #                             |-> "sub", "dir"
             else
                 split(settings.deploy_url, '/') # "sub", "dir"
             end
@@ -118,7 +118,7 @@ function modify_config_file(doc, settings, deploy_decision, i_folder, base)
             isempty(s) ? "/" : "/$(s)"
         end
 
-    base_str = deploy_abspath == "/" ? "base: '$(deploy_abspath)$(deploy_relpath)'" : "base: '$(deploy_abspath)/$(deploy_relpath)'"
+    base_str = endswith(deploy_abspath, "/") ? "base: '$(deploy_abspath)$(deploy_relpath)'" : "base: '$(deploy_abspath)/$(deploy_relpath)'"
 
     push!(replacers, "REPLACE_ME_DOCUMENTER_VITEPRESS_DEPLOY_ABSPATH" => deploy_abspath)
     push!(replacers, "base: 'REPLACE_ME_DOCUMENTER_VITEPRESS'" => base_str)

--- a/src/vitepress_config.jl
+++ b/src/vitepress_config.jl
@@ -106,13 +106,15 @@ function modify_config_file(doc, settings, deploy_decision, i_folder, base)
             @info "Base is \"\" and ENV[\"CI\"] is not set so this is a local build. Not adding any additional base prefix based on the repository or deploy url and instead using absolute path \"/\" to facilitate serving docs locally."
             "/"
         elseif isnothing(settings.deploy_url)
-            "/" * split(rstrip(settings.repo, '/'), '/')[end]  # Get the last identifier of the repo path, i.e., `user/$repo`.
+            "/" * split(rstrip(settings.repo, '/'), '/')[end]
         else
+            # Full URL: subpath starts at index 4 after scheme+host,
+            # e.g. ["https:", "", "host", "sub", "dir"].
             s_path = if startswith(settings.deploy_url, r"^https?://")
-                frags = split(rstrip(settings.deploy_url, '/'), '/') # "https", "", "my.custom.domain", "sub", "dir"
-                length(frags) >= 4 ? frags[4:end] : [""] #                             |-> "sub", "dir"
+                frags = split(rstrip(settings.deploy_url, '/'), '/')
+                length(frags) >= 4 ? frags[4:end] : [""]
             else
-                split(rstrip(settings.deploy_url, '/'), '/') # "sub", "dir"
+                split(rstrip(settings.deploy_url, '/'), '/')
             end
             s = join(s_path, '/')
             isempty(s) ? "/" : "/$(s)"


### PR DESCRIPTION
Extracted from the `as/plugin-extension-hooks` stack (originally bundled into #278), rebased onto `main`. One of several orthogonal PRs split out of that stack.

## What
Fixes how `modify_config_file` derives the VitePress `base` path from `repo` / `deploy_url`:

- Use `split(s, '/')` instead of `splitpath` — `splitpath` mangles URLs (and is OS path-separator dependent), producing wrong base paths.
- Correctly extract the subpath for custom-domain deploy URLs like `https://my.custom.domain/sub/dir` (take fragments from index 4) and join multi-segment subpaths.
- `base_str` now checks `endswith(deploy_abspath, "/")` rather than `== "/"`, so non-root absolute paths get the separating slash inserted correctly.

## Notes
- Test suite (incl. the full VitePress round-trip) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
