### PR TITLE
Make inventory (objects.inv) writing optional via write_inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## unreleased
+- Added a `write_inventory` option to `MarkdownVitepress` (default `true`); set it to `false` to skip writing the `objects.inv` inventory [#360](https://github.com/LuxDL/DocumenterVitepress.jl/pull/360)
 - Interactive `text/html` show output that contains `<script>` tags (e.g. WGLMakie/Bonito figures, Plotly) now actually runs. Such output is wrapped in `<ClientOnly>` (so the potentially-multi-MB widget is not server-rendered) and its scripts are executed on the client via a new `v-exec-scripts` directive, on the initial render and on client-side navigation — previously `v-html` set `innerHTML`, whose `<script>` tags the browser never executes, so figures only appeared on a hard reload. Script-free HTML output keeps the plain server-rendered `v-html` path.
 - Added a GitHub Actions workflow for posting a PR preview comment with a link to the documentation preview. The workflow automatically reads `deploy_repo` from `docs/make.jl` to support cross-repository deployments, and only runs on PRs from the same repository (not forks) [#355](https://github.com/LuxDL/DocumenterVitepress.jl/pull/355)
 

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -66,6 +66,8 @@ Base.@kwdef struct MarkdownVitepress <: Documenter.Writer
     inventory_version::Union{String,Nothing} = nothing
     """Enables a sidebar drawer toggle button on desktop. When enabled, a small chevron button appears at the edge of the sidebar, allowing users to collapse and expand it. The collapsed state is persisted in `localStorage`. Defaults to `false`."""
     sidebar_drawer::Bool = false
+    "Whether to write inventory or not"
+    write_inventory = true
     """
     Sets the granularity of versions which should be kept. Options are :patch, :minor or :breaking (the default).
     You can use this to reduce the number of docs versions that coexist on your dev branch. With :patch, every patch
@@ -219,30 +221,41 @@ function render(doc::Documenter.Document, settings::MarkdownVitepress=MarkdownVi
         end
     end
 
-    version = settings.inventory_version
-    if isnothing(version)
-        project_toml = joinpath(dirname(doc.user.root), "Project.toml")
-        version = _get_inventory_version(project_toml)
+    inventory = if settings.write_inventory
+        version = settings.inventory_version
+        if isnothing(version)
+            project_toml = joinpath(dirname(doc.user.root), "Project.toml")
+            version = _get_inventory_version(project_toml)
+        end
+        Inventory(; project=doc.user.sitename, version)
+    else
+        nothing
     end
-    inventory = Inventory(; project=doc.user.sitename, version)
 
     # Iterate over the pages, render each page separately
     for (src, page) in doc.blueprint.pages
         # This is where you can operate on a per-page level.
         open(docpath(page.build, builddir, settings.md_output_path), "w") do io
             for node in page.mdast.children
-                render(io, mime, node, page, doc; inventory)
+                kwargs = if settings.write_inventory
+                    (; inventory = inventory)
+                else
+                    (;)
+                end
+                render(io, mime, node, page, doc; kwargs...)
             end
         end
-        item = InventoryItem(
-            name = replace(splitext(src)[1], "\\" => "/"),
-            domain = "std",
-            role = "doc",
-            dispname = _pagetitle(page),
-            priority = -1,
-            uri = _get_inventory_uri(doc, page, nothing)
-        )
-        push!(inventory, item)
+        if settings.write_inventory
+            item = InventoryItem(
+                name = replace(splitext(src)[1], "\\" => "/"),
+                domain = "std",
+                role = "doc",
+                dispname = _pagetitle(page),
+                priority = -1,
+                uri = _get_inventory_uri(doc, page, nothing)
+            )
+            push!(inventory, item)
+        end
     end
 
     objects_inv = joinpath(builddir, settings.md_output_path, "public", "objects.inv")

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -257,9 +257,10 @@ function render(doc::Documenter.Document, settings::MarkdownVitepress=MarkdownVi
             push!(inventory, item)
         end
     end
-
-    objects_inv = joinpath(builddir, settings.md_output_path, "public", "objects.inv")
-    DocInventories.save(objects_inv, inventory)
+    if settings.write_inventory
+        objects_inv = joinpath(builddir, settings.md_output_path, "public", "objects.inv")
+        DocInventories.save(objects_inv, inventory)
+    end
 
     bases = determine_bases(deploy_decision.subfolder; settings.keep)
 

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -67,7 +67,7 @@ Base.@kwdef struct MarkdownVitepress <: Documenter.Writer
     """Enables a sidebar drawer toggle button on desktop. When enabled, a small chevron button appears at the edge of the sidebar, allowing users to collapse and expand it. The collapsed state is persisted in `localStorage`. Defaults to `false`."""
     sidebar_drawer::Bool = false
     "Whether to write inventory or not"
-    write_inventory = true
+    write_inventory::Bool = true
     """
     Sets the granularity of versions which should be kept. Options are :patch, :minor or :breaking (the default).
     You can use this to reduce the number of docs versions that coexist on your dev branch. With :patch, every patch


### PR DESCRIPTION
Extracted from the `as/plugin-extension-hooks` stack (originally bundled into #278), rebased onto `main`. One of several orthogonal PRs split out of that stack.

## What
Adds a `write_inventory::Bool = true` setting to `MarkdownVitepress`. When `false`, DocumenterVitepress skips building the `Inventory`, attaching per-page `InventoryItem`s, and saving `public/objects.inv`. Default stays `true`, so existing behavior is unchanged.

Useful for sites that don't want a Documenter inventory emitted.

## Notes
- Test suite (incl. the full VitePress round-trip) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
