### PR TITLE
Add noindex_non_stable to keep dev/preview docs out of search engines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## unreleased
+- Added a `noindex_non_stable` option to `MarkdownVitepress` (default `true`) that injects a `noindex, nofollow` robots meta into non-stable, non-root deployments so search engines only index the stable docs [#361](https://github.com/LuxDL/DocumenterVitepress.jl/pull/361)
 - Interactive `text/html` show output that contains `<script>` tags (e.g. WGLMakie/Bonito figures, Plotly) now actually runs. Such output is wrapped in `<ClientOnly>` (so the potentially-multi-MB widget is not server-rendered) and its scripts are executed on the client via a new `v-exec-scripts` directive, on the initial render and on client-side navigation — previously `v-html` set `innerHTML`, whose `<script>` tags the browser never executes, so figures only appeared on a hard reload. Script-free HTML output keeps the plain server-rendered `v-html` path.
 - Added a GitHub Actions workflow for posting a PR preview comment with a link to the documentation preview. The workflow automatically reads `deploy_repo` from `docs/make.jl` to support cross-repository deployments, and only runs on PRs from the same repository (not forks) [#355](https://github.com/LuxDL/DocumenterVitepress.jl/pull/355)
 

--- a/src/vitepress_config.jl
+++ b/src/vitepress_config.jl
@@ -153,6 +153,13 @@ function modify_config_file(doc, settings, deploy_decision, i_folder, base)
     # # Sidebar drawer toggle
     push!(replacers, "sidebarDrawer: 'REPLACE_ME_DOCUMENTER_VITEPRESS_SIDEBAR_DRAWER'" => "sidebarDrawer: $(settings.sidebar_drawer)")
 
+    # # Noindex for non-stable deployments
+    if settings.noindex_non_stable && base != "stable"
+        push!(replacers, "// REPLACE_ME_DOCUMENTER_VITEPRESS_NOINDEX" => "['meta', { name: 'robots', content: 'noindex, nofollow' }],")
+    else
+        push!(replacers, "// REPLACE_ME_DOCUMENTER_VITEPRESS_NOINDEX" => "")
+    end
+
     # # Favicon
 
     if occursin("rel: 'icon', href: 'REPLACE_ME_DOCUMENTER_VITEPRESS_FAVICON'", config)

--- a/src/vitepress_config.jl
+++ b/src/vitepress_config.jl
@@ -200,14 +200,17 @@ found, a warning is emitted and the config is returned unchanged.
 """
 function apply_noindex(config::AbstractString, noindex_non_stable::Bool, base::AbstractString)
     marker = "// REPLACE_ME_DOCUMENTER_VITEPRESS_NOINDEX"
-    if !(noindex_non_stable && base != "stable")
+    # An empty `base` is the root deployment (single-version sites) and must stay indexable.
+    if !(noindex_non_stable && base != "stable" && !isempty(base))
         return replace(config, marker => "")
     end
     head_entry = "['meta', { name: 'robots', content: 'noindex, nofollow' }],"
     if occursin(marker, config)
         return replace(config, marker => head_entry)
     end
-    m = match(r"head:\s*\[", config)
+    # Match `head: [` with optional quotes around the key and flexible whitespace
+    # (`head:[`, `'head': [`, `"head" : [`, …).
+    m = match(r"['\"]?head['\"]?\s*:\s*\[", config)
     if m !== nothing
         return replace(config, m.match => "$(m.match)\n    $(head_entry)"; count = 1)
     end

--- a/src/vitepress_config.jl
+++ b/src/vitepress_config.jl
@@ -154,11 +154,8 @@ function modify_config_file(doc, settings, deploy_decision, i_folder, base)
     push!(replacers, "sidebarDrawer: 'REPLACE_ME_DOCUMENTER_VITEPRESS_SIDEBAR_DRAWER'" => "sidebarDrawer: $(settings.sidebar_drawer)")
 
     # # Noindex for non-stable deployments
-    if settings.noindex_non_stable && base != "stable"
-        push!(replacers, "// REPLACE_ME_DOCUMENTER_VITEPRESS_NOINDEX" => "['meta', { name: 'robots', content: 'noindex, nofollow' }],")
-    else
-        push!(replacers, "// REPLACE_ME_DOCUMENTER_VITEPRESS_NOINDEX" => "")
-    end
+    # Handled separately in `apply_noindex` (after the other replacers run)
+    # so that user configs without the marker still get the meta tag injected.
 
     # # Favicon
 
@@ -174,6 +171,10 @@ function modify_config_file(doc, settings, deploy_decision, i_folder, base)
     # Finally, run all the replacers and write the new config file
 
     new_config = replace(config, replacers...)
+
+    # Noindex for non-stable deployments
+    new_config = apply_noindex(new_config, settings.noindex_non_stable, base)
+
     write(vitepress_config_file, new_config)
     yield()
     touch(vitepress_config_file)
@@ -182,6 +183,40 @@ function modify_config_file(doc, settings, deploy_decision, i_folder, base)
 end
 
 function _get_raw_text(element)
+end
+
+"""
+    apply_noindex(config::AbstractString, noindex_non_stable::Bool, base::AbstractString) -> String
+
+Add a `noindex, nofollow` robots meta tag to the VitePress `config` string when
+`noindex_non_stable` is enabled and `base` is not `"stable"`, so that search
+engines only index the stable deployment.
+
+The tag replaces the `// REPLACE_ME_DOCUMENTER_VITEPRESS_NOINDEX` marker if
+present (as in the package template). User-supplied configs forked from older
+templates may lack the marker, in which case the tag is injected at the start
+of the `head` array instead; if neither the marker nor a `head` array can be
+found, a warning is emitted and the config is returned unchanged.
+"""
+function apply_noindex(config::AbstractString, noindex_non_stable::Bool, base::AbstractString)
+    marker = "// REPLACE_ME_DOCUMENTER_VITEPRESS_NOINDEX"
+    if !(noindex_non_stable && base != "stable")
+        return replace(config, marker => "")
+    end
+    head_entry = "['meta', { name: 'robots', content: 'noindex, nofollow' }],"
+    if occursin(marker, config)
+        return replace(config, marker => head_entry)
+    end
+    m = match(r"head:\s*\[", config)
+    if m !== nothing
+        return replace(config, m.match => "$(m.match)\n    $(head_entry)"; count = 1)
+    end
+    @warn """
+    DocumenterVitepress: `noindex_non_stable` is enabled and this build (base = $(repr(base))) should not be indexed,
+    but the config file contains neither the `$marker` marker nor a `head` array to inject the robots meta tag into.
+    Search engines may index this deployment. Add the marker inside the `head` array of `docs/src/.vitepress/config.mts`.
+    """
+    return config
 end
 
 function pagelist2str(doc, page::String)

--- a/src/vitepress_config.jl
+++ b/src/vitepress_config.jl
@@ -188,19 +188,13 @@ end
 """
     apply_noindex(config::AbstractString, noindex_non_stable::Bool, base::AbstractString) -> String
 
-Add a `noindex, nofollow` robots meta tag to the VitePress `config` string when
-`noindex_non_stable` is enabled and `base` is not `"stable"`, so that search
-engines only index the stable deployment.
-
-The tag replaces the `// REPLACE_ME_DOCUMENTER_VITEPRESS_NOINDEX` marker if
-present (as in the package template). User-supplied configs forked from older
-templates may lack the marker, in which case the tag is injected at the start
-of the `head` array instead; if neither the marker nor a `head` array can be
-found, a warning is emitted and the config is returned unchanged.
+Inject a `noindex, nofollow` robots meta into `config` for non-stable, non-root
+deployments. Replaces the marker if present, else injects into the `head` array;
+warns and returns `config` unchanged if neither is found.
 """
 function apply_noindex(config::AbstractString, noindex_non_stable::Bool, base::AbstractString)
     marker = "// REPLACE_ME_DOCUMENTER_VITEPRESS_NOINDEX"
-    # An empty `base` is the root deployment (single-version sites) and must stay indexable.
+    # Empty base = root deploy (single-version); keep it indexable.
     if !(noindex_non_stable && base != "stable" && !isempty(base))
         return replace(config, marker => "")
     end
@@ -208,8 +202,7 @@ function apply_noindex(config::AbstractString, noindex_non_stable::Bool, base::A
     if occursin(marker, config)
         return replace(config, marker => head_entry)
     end
-    # Match `head: [` with optional quotes around the key and flexible whitespace
-    # (`head:[`, `'head': [`, `"head" : [`, …).
+    # Match `head: [`, allowing quoted keys and flexible whitespace.
     m = match(r"['\"]?head['\"]?\s*:\s*\[", config)
     if m !== nothing
         return replace(config, m.match => "$(m.match)\n    $(head_entry)"; count = 1)

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -67,7 +67,7 @@ Base.@kwdef struct MarkdownVitepress <: Documenter.Writer
     """Enables a sidebar drawer toggle button on desktop. When enabled, a small chevron button appears at the edge of the sidebar, allowing users to collapse and expand it. The collapsed state is persisted in `localStorage`. Defaults to `false`."""
     sidebar_drawer::Bool = false
     "Whether to add a `noindex` meta tag to non-stable deployments, preventing search engines from indexing dev/preview docs."
-    noindex_non_stable::Bool = false
+    noindex_non_stable::Bool = true
     """
     Sets the granularity of versions which should be kept. Options are :patch, :minor or :breaking (the default).
     You can use this to reduce the number of docs versions that coexist on your dev branch. With :patch, every patch

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -66,6 +66,8 @@ Base.@kwdef struct MarkdownVitepress <: Documenter.Writer
     inventory_version::Union{String,Nothing} = nothing
     """Enables a sidebar drawer toggle button on desktop. When enabled, a small chevron button appears at the edge of the sidebar, allowing users to collapse and expand it. The collapsed state is persisted in `localStorage`. Defaults to `false`."""
     sidebar_drawer::Bool = false
+    "Whether to add a `noindex` meta tag to non-stable deployments, preventing search engines from indexing dev/preview docs."
+    noindex_non_stable::Bool = false
     """
     Sets the granularity of versions which should be kept. Options are :patch, :minor or :breaking (the default).
     You can use this to reduce the number of docs versions that coexist on your dev branch. With :patch, every patch

--- a/template/src/.vitepress/config.mts
+++ b/template/src/.vitepress/config.mts
@@ -40,7 +40,8 @@ export default defineConfig({
     ['link', { rel: 'icon', href: 'REPLACE_ME_DOCUMENTER_VITEPRESS_FAVICON' }],
     ['script', {src: `${getBaseRepository(baseTemp.base)}versions.js`}],
     // ['script', {src: '/versions.js'], for custom domains, I guess if deploy_url is available.
-    ['script', {src: `${baseTemp.base}siteinfo.js`}]
+    ['script', {src: `${baseTemp.base}siteinfo.js`}],
+    // REPLACE_ME_DOCUMENTER_VITEPRESS_NOINDEX
   ],
   
   markdown: {

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -189,8 +189,7 @@ end
     @test !occursin("noindex", out)
     @test !occursin(marker, out)
 
-    # User-supplied config forked from an older template: no marker, but a
-    # `head` array is present -> the meta entry is injected into `head`.
+    # User config (no marker) but with a `head` array -> injected into `head`.
     user_config = """
     export default defineConfig({
       head: [

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -153,3 +153,58 @@ end
         @test json_title.captures[1] == "PDF & SVG"
     end
 end
+
+@testset "noindex injection" begin
+    apply_noindex = DocumenterVitepress.apply_noindex
+    marker = "// REPLACE_ME_DOCUMENTER_VITEPRESS_NOINDEX"
+    meta = "['meta', { name: 'robots', content: 'noindex, nofollow' }],"
+
+    # Config like the package template: marker present inside `head`.
+    template_config = """
+    export default defineConfig({
+      head: [
+        ['link', { rel: 'icon', href: 'favicon.ico' }],
+        $marker
+      ],
+    })
+    """
+
+    # Non-stable base -> marker replaced with the robots meta entry.
+    out = apply_noindex(template_config, true, "v1.2.3")
+    @test occursin(meta, out)
+    @test !occursin(marker, out)
+
+    # Stable base -> marker removed, no robots meta emitted.
+    out = apply_noindex(template_config, true, "stable")
+    @test !occursin("noindex", out)
+    @test !occursin(marker, out)
+
+    # Feature disabled -> marker removed, no robots meta emitted.
+    out = apply_noindex(template_config, false, "dev")
+    @test !occursin("noindex", out)
+    @test !occursin(marker, out)
+
+    # User-supplied config forked from an older template: no marker, but a
+    # `head` array is present -> the meta entry is injected into `head`.
+    user_config = """
+    export default defineConfig({
+      head: [
+        ['link', { rel: 'icon', href: 'favicon.ico' }],
+      ],
+    })
+    """
+    out = apply_noindex(user_config, true, "dev")
+    @test occursin(meta, out)
+    @test first(findfirst(meta, out)) > first(findfirst("head: [", out)) # inside `head`
+    out = apply_noindex(user_config, true, "v1.2")
+    @test occursin(meta, out)
+    out = apply_noindex(user_config, true, "stable")
+    @test !occursin("noindex", out)
+    out = apply_noindex(user_config, false, "dev")
+    @test !occursin("noindex", out)
+
+    # No marker and no `head` array at all -> warn, leave config unchanged.
+    bare_config = "export default defineConfig({ title: 'x' })"
+    out = @test_logs (:warn,) match_mode = :any apply_noindex(bare_config, true, "dev")
+    @test out == bare_config
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -179,6 +179,11 @@ end
     @test !occursin("noindex", out)
     @test !occursin(marker, out)
 
+    # Root base (empty string) -> root / single-version deploy stays indexable.
+    out = apply_noindex(template_config, true, "")
+    @test !occursin("noindex", out)
+    @test !occursin(marker, out)
+
     # Feature disabled -> marker removed, no robots meta emitted.
     out = apply_noindex(template_config, false, "dev")
     @test !occursin("noindex", out)
@@ -202,6 +207,17 @@ end
     @test !occursin("noindex", out)
     out = apply_noindex(user_config, false, "dev")
     @test !occursin("noindex", out)
+
+    # Quoted `head` key (as a linter/formatter may emit) is still matched.
+    quoted_config = """
+    export default defineConfig({
+      "head": [
+        ['link', { rel: 'icon', href: 'favicon.ico' }],
+      ],
+    })
+    """
+    out = apply_noindex(quoted_config, true, "dev")
+    @test occursin(meta, out)
 
     # No marker and no `head` array at all -> warn, leave config unchanged.
     bare_config = "export default defineConfig({ title: 'x' })"


### PR DESCRIPTION
## What
Adds a `noindex_non_stable::Bool = true` setting. For any deployment whose base isn't `"stable"` (dev, preview, per-version folders), DocumenterVitepress injects a `['meta', { name: 'robots', content: 'noindex, nofollow' }]` head entry so search engines only index the stable docs.

This is the same thing Documenter.jl does and helps tremendously with SEO.

Covered by the new `noindex injection` testset (13 assertions).

## Notes
- ⚠️ Default is `true`, so non-stable deployments become no-indexed out of the box — a behavior change for existing users (generally desirable, but worth a look).
- 
🤖 Generated with [Claude Code](https://claude.com/claude-code)
