### PR TITLE
Surface npm install errors instead of a bare ProcessExited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## unreleased
+- `npm install` failures now surface the captured npm stderr/stdout via `@error` instead of a bare `ProcessExited` [#362](https://github.com/LuxDL/DocumenterVitepress.jl/pull/362)
 - Interactive `text/html` show output that contains `<script>` tags (e.g. WGLMakie/Bonito figures, Plotly) now actually runs. Such output is wrapped in `<ClientOnly>` (so the potentially-multi-MB widget is not server-rendered) and its scripts are executed on the client via a new `v-exec-scripts` directive, on the initial render and on client-side navigation — previously `v-html` set `innerHTML`, whose `<script>` tags the browser never executes, so figures only appeared on a hard reload. Script-free HTML output keeps the plain server-rendered `v-html` path.
 - Added a GitHub Actions workflow for posting a PR preview comment with a link to the documentation preview. The workflow automatically reads `deploy_repo` from `docs/make.jl` to support cross-repository deployments, and only runs on PRs from the same repository (not forks) [#355](https://github.com/LuxDL/DocumenterVitepress.jl/pull/355)
 

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -326,8 +326,7 @@ function build_vitepress(bases, base, i_base, builddir, subfolder, settings)
                         @warn "On Windows, use `npm run docs:dev` and `npm run docs:build` directly in the terminal inside your `docs` folder."
                         @info "Go to https://nodejs.org/en, download, and install the latest version. Version 22.11.0 or higher should work."
                     else
-                        # Capture output so a failed install surfaces npm's real
-                        # error instead of a bare `ProcessExited`; quiet on success.
+                        # Surface npm's real error, not a bare ProcessExited.
                         npm_out = IOBuffer()
                         npm_err = IOBuffer()
                         try

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -335,8 +335,10 @@ function build_vitepress(bases, base, i_base, builddir, subfolder, settings)
                         catch e
                             stdout_text = String(take!(npm_out))
                             stderr_text = String(take!(npm_err))
-                            isempty(stdout_text) || println(stderr, "── npm install stdout ──\n", stdout_text)
-                            isempty(stderr_text) || println(stderr, "── npm install stderr ──\n", stderr_text)
+                            log_msg = "npm install failed"
+                            isempty(stdout_text) || (log_msg *= "\n── npm install stdout ──\n" * stdout_text)
+                            isempty(stderr_text) || (log_msg *= "\n── npm install stderr ──\n" * stderr_text)
+                            @error log_msg
                             rethrow(e)
                         end
                         run(`$(npm) run env -- vitepress build $(build_output_path)`)

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -326,7 +326,19 @@ function build_vitepress(bases, base, i_base, builddir, subfolder, settings)
                         @warn "On Windows, use `npm run docs:dev` and `npm run docs:build` directly in the terminal inside your `docs` folder."
                         @info "Go to https://nodejs.org/en, download, and install the latest version. Version 22.11.0 or higher should work."
                     else
-                        run(`$(npm) install`)
+                        # Capture output so a failed install surfaces npm's real
+                        # error instead of a bare `ProcessExited`; quiet on success.
+                        npm_out = IOBuffer()
+                        npm_err = IOBuffer()
+                        try
+                            run(pipeline(`$(npm) install`; stdout=npm_out, stderr=npm_err))
+                        catch e
+                            stdout_text = String(take!(npm_out))
+                            stderr_text = String(take!(npm_err))
+                            isempty(stdout_text) || println(stderr, "── npm install stdout ──\n", stdout_text)
+                            isempty(stderr_text) || println(stderr, "── npm install stderr ──\n", stderr_text)
+                            rethrow(e)
+                        end
                         run(`$(npm) run env -- vitepress build $(build_output_path)`)
                     end
                 end


### PR DESCRIPTION
Extracted from the `as/plugin-extension-hooks` stack, rebased onto `main`. One of several orthogonal PRs split out of that stack.

## What
When `npm install` fails during a VitePress build, Julia previously surfaced only a bare `failed process … ProcessExited(1)` with none of npm's diagnostics. This captures `npm install`'s stdout/stderr and prints them on failure (then rethrows), so the real cause — script-exit, `EBADENGINE`, a peer-dep conflict, etc. — is visible. Successful installs stay quiet.

## Notes
- Test suite (incl. the full VitePress round-trip, which exercises a real `npm install`) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
