### PR TITLE
fix(template): declare @mathjax/src as explicit dependency

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@nolebase/vitepress-plugin-enhanced-readabilities": "^2.18.2",
+    "@mathjax/src": "^4.1.2",
     "@mdit/plugin-mathjax": "^0.26.1",
     "@mdit/plugin-tex": "^0.24.1",
     "markdown-it-footnote": "^4.0.0",


### PR DESCRIPTION
## What

`template/src/.vitepress/mathjax-plugin.ts` imports `@mathjax/src` directly (`MathJax.init`, `MathJax.tex2svg`, `MathJax.startup`, etc., plus `paths: { mathjax: '@mathjax/src/bundle' }`), but `template/package.json` never declared `@mathjax/src` as a dependency. It only declares `@mdit/plugin-mathjax` (`^0.26.1`), which happens to declare `@mathjax/src: ^4.1.1` as its own dependency — so `@mathjax/src` has only ever resolved transitively.

This PR makes that dependency explicit:

```diff
     "@nolebase/vitepress-plugin-enhanced-readabilities": "^2.18.2",
+    "@mathjax/src": "^4.1.2",
     "@mdit/plugin-mathjax": "^0.26.1",
     "@mdit/plugin-tex": "^0.24.1",
```

## Why

Relying on a transitive resolution here is fragile:

- If `@mdit/plugin-mathjax` ever drops or changes its `@mathjax/src` dependency, the template silently breaks.
- DocumenterVitepress does **not** overwrite a downstream repo's own checked-in `docs/package.json` if one already exists. If that file predates this dependency (or otherwise lacks a compatible transitive resolution), the VitePress build crashes with `Cannot find package '@mathjax/src' ... ERR_MODULE_NOT_FOUND`.

This exact crash was just observed in a downstream repo (lazarusA/TemplateDocsVitePress.jl) while testing #359 against downstream repos — its `docs/package.json` predates this dependency entirely. Declaring `@mathjax/src` explicitly gives the template (and any repo copying from it) a clear, correct, directly-resolvable dependency instead of relying on an implementation detail of `@mdit/plugin-mathjax`.

## Testing

- `cd template && npm install` completes cleanly; `node_modules/@mathjax/src` is installed at `4.1.2`.
- `Pkg.test()` passes, including the `heading escaping (full vitepress round-trip)` testset, which exercises a real `Documenter.makedocs` → `build_vitepress` → `vitepress build` round trip using this template (via `NodeJS_20_jll`). No MathJax or build errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)