### PR TITLE
Render ANSI-colored `@repl` output in a single block (#373)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- Fixed ANSI-colored `@repl` output (e.g. from StyledStrings or colored `show` methods) rendering as raw escape codes. `@repl` output whose text carries ANSI escapes is now emitted as a single `ansi` fence annotated with a `julia-repl-runs=` spec, and the `julia-repl-transformer` re-highlights the input as `julia` and the output as `ansi` into one `<pre>` — matching Documenter's HTML output (syntax-highlighted input, colored output in one box). Colorless `@repl` blocks are unchanged [#373](https://github.com/LuxDL/DocumenterVitepress.jl/issues/373)
 - Fixed missing root `index.html` redirect on deploy: `Documenter.deploydocs` writes this for its standard `versions=` argument, but `DocumenterVitepress.deploydocs` uses a custom `versions` type that bypasses that code path, so a freshly-deployed site had nothing at its root and 404'd instead of redirecting to `stable`/`dev` [#368](https://github.com/LuxDL/DocumenterVitepress.jl/pull/368)
 - Made sidebar/navbar generation overloadable: `pagelist2str` now dispatches on a `Val{:sidebar}`/`Val{:navbar}` tag (with a `get_title` helper), so a custom `make.jl` can control how pages map to VitePress nav entries [#357](https://github.com/LuxDL/DocumenterVitepress.jl/pull/357)
 - Fixed VitePress `base`-path derivation from `repo`/`deploy_url`: split on `/` instead of `splitpath` (which mangled URLs), support custom-domain subpaths, and strip trailing slashes [#359](https://github.com/LuxDL/DocumenterVitepress.jl/pull/359)

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -5,6 +5,7 @@ DocumenterCitations = "daee34ce-89f3-4625-b898-19384cb65244"
 DocumenterInterLinks = "d12716ef-a0f6-4df4-a9f1-a5a34e75c656"
 DocumenterVitepress = "4710194d-e776-4893-9690-8d956a29c365"
 LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
+StyledStrings = "f489334b-da3d-4c2e-b8f0-e476e12c162b"
 
 [sources]
 DocumenterVitepress = {path = ".."}

--- a/docs/src/manual/code_example.md
+++ b/docs/src/manual/code_example.md
@@ -184,6 +184,26 @@ b = 2; # hide
 a + b
 ```
 
+### Colored output
+
+Output carrying ANSI color codes (e.g. from [`StyledStrings`](https://docs.julialang.org/en/v1/stdlib/StyledStrings/) or a colored `show` method) is rendered in color, with the input still syntax-highlighted.
+
+**Input**
+
+````
+```@repl
+using StyledStrings
+styled"{red:red} {green:green} {blue:blue} {cyan,bold:cyan bold}"
+```
+````
+
+**Output**
+
+```@repl
+using StyledStrings
+styled"{red:red} {green:green} {blue:blue} {cyan,bold:cyan bold}"
+```
+
 ## @doctest
 **Input**
 ````

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -763,21 +763,67 @@ function join_multiblock(node::Documenter.MarkdownAST.Node)
         # push the last code block
         push!(codes, Markdown.Code(intelligent_language(current_language), current_string))
         return codes
+    end
 
-    else
-        io = IOBuffer()
-        codeblocks = [n.element::MarkdownAST.CodeBlock for n in node.children]
-        for (i, thing) in enumerate(codeblocks)
-            print(io, thing.code)
-            if i != length(codeblocks)
-              !isempty(thing.code) && println(io)
-                if findnext(x -> x.info == mcb.language, codeblocks, i + 1) == i + 1
-                    println(io)
-                end
+    # Every other MultiCodeBlock is currently Documenter's `@repl` block
+    # (`mcb.language == "julia-repl"`), whose children live in `node.children` as
+    # interleaved input (`julia-repl`) and output (`documenter-ansi`) code blocks.
+    codeblocks = [n.element::MarkdownAST.CodeBlock for n in node.children]
+
+    # `@repl` output is tagged `documenter-ansi`.  When `ansicolor` is enabled
+    # (e.g. via `writer_supports_ansicolor(::MarkdownVitepress)`) it may carry raw
+    # ANSI escape codes from colored `show` methods / StyledStrings.  If any
+    # output actually does, emit the whole transcript as a *single* `ansi` fence
+    # annotated with a `julia-repl-runs=` spec (`lang:linecount` per run, in
+    # order).  Our Shiki transformer (`julia-repl-transformer.ts`) reads that spec
+    # and re-highlights the input runs as `julia` and the output runs as `ansi`,
+    # assembling one `<pre>` -- so the block looks like Documenter's HTML output
+    # (Julia-highlighted input + colored output in a single box) instead of
+    # showing raw escape codes.  See
+    # https://github.com/LuxDL/DocumenterVitepress.jl/issues/373.  When there is
+    # no color we keep the previous single-`julia`-block layout unchanged.
+    if any(cb -> occursin('\e', cb.code), codeblocks)
+        # Build the transcript line-by-line, tagging each line with the Shiki
+        # language of the run it belongs to, reproducing the same blank-line
+        # spacing between REPL entries as the plain path below.
+        lines = String[]
+        line_langs = String[]
+        for (i, cb) in enumerate(codeblocks)
+            lang = intelligent_language(cb.info)  # "julia" (input) or "ansi" (output)
+            if i > 1 && cb.info == mcb.language
+                # a blank line precedes each input entry (mirrors the plain layout)
+                push!(lines, ""); push!(line_langs, lang)
+            end
+            for line in split(cb.code, '\n')
+                push!(lines, line); push!(line_langs, lang)
             end
         end
-        return [Markdown.Code(intelligent_language(mcb.language), String(take!(io)))]
+        # Compress consecutive same-language lines into `lang:linecount` runs.
+        runs = Tuple{String, Int}[]
+        for lang in line_langs
+            if !isempty(runs) && runs[end][1] == lang
+                runs[end] = (lang, runs[end][2] + 1)
+            else
+                push!(runs, (lang, 1))
+            end
+        end
+        spec = join(("$lang:$count" for (lang, count) in runs), ",")
+        return [Markdown.Code("ansi julia-repl-runs=$spec", join(lines, '\n'))]
     end
+
+    # No ANSI color: keep the previous single-block layout so plain REPL
+    # transcripts render as one contiguous `julia` code block.
+    io = IOBuffer()
+    for (i, thing) in enumerate(codeblocks)
+        print(io, thing.code)
+        if i != length(codeblocks)
+          !isempty(thing.code) && println(io)
+            if findnext(x -> x.info == mcb.language, codeblocks, i + 1) == i + 1
+                println(io)
+            end
+        end
+    end
+    return [Markdown.Code(intelligent_language(mcb.language), String(take!(io)))]
 end
 
 function render(io::IO, mime::MIME"text/plain", node::Documenter.MarkdownAST.Node, mcb::Documenter.MultiCodeBlock, page, doc; kwargs...)

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -765,40 +765,25 @@ function join_multiblock(node::Documenter.MarkdownAST.Node)
         return codes
     end
 
-    # Every other MultiCodeBlock is currently Documenter's `@repl` block
-    # (`mcb.language == "julia-repl"`), whose children live in `node.children` as
-    # interleaved input (`julia-repl`) and output (`documenter-ansi`) code blocks.
+    # `@repl` children: `julia-repl` input and `documenter-ansi` output.
     codeblocks = [n.element::MarkdownAST.CodeBlock for n in node.children]
 
-    # `@repl` output is tagged `documenter-ansi`.  When `ansicolor` is enabled
-    # (e.g. via `writer_supports_ansicolor(::MarkdownVitepress)`) it may carry raw
-    # ANSI escape codes from colored `show` methods / StyledStrings.  If any
-    # output actually does, emit the whole transcript as a *single* `ansi` fence
-    # annotated with a `julia-repl-runs=` spec (`lang:linecount` per run, in
-    # order).  Our Shiki transformer (`julia-repl-transformer.ts`) reads that spec
-    # and re-highlights the input runs as `julia` and the output runs as `ansi`,
-    # assembling one `<pre>` -- so the block looks like Documenter's HTML output
-    # (Julia-highlighted input + colored output in a single box) instead of
-    # showing raw escape codes.  See
-    # https://github.com/LuxDL/DocumenterVitepress.jl/issues/373.  When there is
-    # no color we keep the previous single-`julia`-block layout unchanged.
+    # ANSI output: emit one `ansi` fence with a `julia-repl-runs` spec for
+    # julia-repl-transformer.ts; else a plain single `julia` block (below).
     if any(cb -> occursin('\e', cb.code), codeblocks)
-        # Build the transcript line-by-line, tagging each line with the Shiki
-        # language of the run it belongs to, reproducing the same blank-line
-        # spacing between REPL entries as the plain path below.
+        # Per-line (text, run-language); blank line before each input entry.
         lines = String[]
         line_langs = String[]
         for (i, cb) in enumerate(codeblocks)
-            lang = intelligent_language(cb.info)  # "julia" (input) or "ansi" (output)
+            lang = intelligent_language(cb.info)  # "julia" or "ansi"
             if i > 1 && cb.info == mcb.language
-                # a blank line precedes each input entry (mirrors the plain layout)
                 push!(lines, ""); push!(line_langs, lang)
             end
             for line in split(cb.code, '\n')
                 push!(lines, line); push!(line_langs, lang)
             end
         end
-        # Compress consecutive same-language lines into `lang:linecount` runs.
+        # Collapse into `lang:linecount` runs.
         runs = Tuple{String, Int}[]
         for lang in line_langs
             if !isempty(runs) && runs[end][1] == lang
@@ -811,8 +796,6 @@ function join_multiblock(node::Documenter.MarkdownAST.Node)
         return [Markdown.Code("ansi julia-repl-runs=$spec", join(lines, '\n'))]
     end
 
-    # No ANSI color: keep the previous single-block layout so plain REPL
-    # transcripts render as one contiguous `julia` code block.
     io = IOBuffer()
     for (i, thing) in enumerate(codeblocks)
         print(io, thing.code)

--- a/template/src/.vitepress/julia-repl-transformer.ts
+++ b/template/src/.vitepress/julia-repl-transformer.ts
@@ -1,4 +1,5 @@
 import type { ShikiTransformer } from "shiki"
+import type { Element, ElementContent } from "hast"
 
 type PromptKind = "julia" | "pkg" | null
 
@@ -19,7 +20,9 @@ export function juliaReplTransformer(): ShikiTransformer {
     return { len: 0, kind: null }
   }
 
-  return {
+  // The object is captured in `self` so the `code` hook can pass the transformer
+  // to its own recursive highlighting calls (see below).
+  const self: ShikiTransformer = {
     name: "julia-repl-prompts",
 
     preprocess(code, options) {
@@ -50,5 +53,55 @@ export function juliaReplTransformer(): ShikiTransformer {
         this.addClassToHast(node, `repl-prompt-${info.kind}`)
       }
     },
+
+    // A Documenter `@repl` block whose output carries ANSI color codes is
+    // emitted by DocumenterVitepress as a single `ansi` fence annotated with a
+    // `julia-repl-runs=<lang:linecount,...>` meta (see `join_multiblock` in
+    // `src/writer.jl`).  A code fence can only carry one Shiki grammar, but we
+    // want Julia-syntax-highlighted input *and* ANSI-colored output in one box
+    // -- like Documenter's HTML output.  So we take over rendering: split the
+    // source into the runs described by the meta, re-highlight each run with its
+    // own grammar (`julia` or `ansi`), and stitch the resulting lines back into a
+    // single `<pre>`.  The julia runs are highlighted with this same transformer
+    // so the `julia>` prompt styling above still applies; the recursive calls
+    // carry empty meta, so this hook is a no-op for them (no infinite recursion).
+    code(node) {
+      const raw = (this.options.meta as { __raw?: string } | undefined)?.__raw ?? ""
+      const match = raw.match(/julia-repl-runs=(\S+)/)
+      if (!match) return
+
+      const srcLines = this.source.replace(/\n$/, "").split("\n")
+      const children: ElementContent[] = []
+      let cursor = 0
+      for (const spec of match[1].split(",")) {
+        const [lang, countStr] = spec.split(":")
+        const count = Number(countStr)
+        const text = srcLines.slice(cursor, cursor + count).join("\n")
+        cursor += count
+
+        const hast = this.codeToHast(text, {
+          ...this.options,
+          lang,
+          meta: {},
+          // Re-apply prompt styling to julia input; ansi output needs nothing.
+          transformers: lang === "julia" ? [self] : [],
+        })
+        const pre = hast.children[0] as Element
+        const codeEl = pre.children.find(
+          (c): c is Element => c.type === "element" && c.tagName === "code",
+        )
+        if (!codeEl) continue
+        for (const lineEl of codeEl.children) {
+          if (lineEl.type === "element" && lineEl.tagName === "span") {
+            children.push(lineEl)
+            children.push({ type: "text", value: "\n" })
+          }
+        }
+      }
+      if (children.length > 0) children.pop() // drop the trailing newline
+      node.children = children
+    },
   }
+
+  return self
 }

--- a/template/src/.vitepress/julia-repl-transformer.ts
+++ b/template/src/.vitepress/julia-repl-transformer.ts
@@ -20,8 +20,7 @@ export function juliaReplTransformer(): ShikiTransformer {
     return { len: 0, kind: null }
   }
 
-  // The object is captured in `self` so the `code` hook can pass the transformer
-  // to its own recursive highlighting calls (see below).
+  // `self` lets the `code` hook pass this transformer to its recursive calls.
   const self: ShikiTransformer = {
     name: "julia-repl-prompts",
 
@@ -54,17 +53,9 @@ export function juliaReplTransformer(): ShikiTransformer {
       }
     },
 
-    // A Documenter `@repl` block whose output carries ANSI color codes is
-    // emitted by DocumenterVitepress as a single `ansi` fence annotated with a
-    // `julia-repl-runs=<lang:linecount,...>` meta (see `join_multiblock` in
-    // `src/writer.jl`).  A code fence can only carry one Shiki grammar, but we
-    // want Julia-syntax-highlighted input *and* ANSI-colored output in one box
-    // -- like Documenter's HTML output.  So we take over rendering: split the
-    // source into the runs described by the meta, re-highlight each run with its
-    // own grammar (`julia` or `ansi`), and stitch the resulting lines back into a
-    // single `<pre>`.  The julia runs are highlighted with this same transformer
-    // so the `julia>` prompt styling above still applies; the recursive calls
-    // carry empty meta, so this hook is a no-op for them (no infinite recursion).
+    // `julia-repl-runs=...` fences (writer.jl): re-highlight each run with its
+    // own grammar, stitch into one <pre>. Julia runs reuse this transformer
+    // for prompt styling; their empty meta no-ops this hook.
     code(node) {
       const raw = (this.options.meta as { __raw?: string } | undefined)?.__raw ?? ""
       const match = raw.match(/julia-repl-runs=(\S+)/)
@@ -83,7 +74,7 @@ export function juliaReplTransformer(): ShikiTransformer {
           ...this.options,
           lang,
           meta: {},
-          // Re-apply prompt styling to julia input; ansi output needs nothing.
+          // julia input reuses prompt styling; ansi needs none.
           transformers: lang === "julia" ? [self] : [],
         })
         const pre = hast.children[0] as Element

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -224,6 +224,80 @@ end
     end
 end
 
+@testset "REPL block ANSI color output (issue #373)" begin
+    # A `@repl` block whose result's `text/plain` show emits ANSI escape codes
+    # when `:color` is set (as StyledStrings and many colored `show` methods do)
+    # must be emitted as a SINGLE `ansi` fence carrying a `julia-repl-runs=` spec.
+    # Our Shiki transformer uses that spec to render one <pre> with the input
+    # Julia-highlighted and the output ANSI-colored -- rather than concatenating
+    # everything into a `julia` fence where the raw escape codes would show up
+    # verbatim.  A plain `@repl` block must be unaffected and stay a single
+    # contiguous `julia` transcript.
+    #
+    # The markdown is written flush-left on purpose: leading indentation would
+    # turn the ```@repl fences into indented code blocks.
+    md_content = raw"""
+# Repl ansi
+
+```@repl ansi-demo
+struct Colored end
+Base.show(io::IO, ::MIME"text/plain", ::Colored) = print(io, get(io, :color, false) ? "\e[31mred\e[39m" : "red")
+Colored()
+```
+
+```@repl plain-demo
+1 + 1
+```
+"""
+    mktempdir() do dir
+        dir = realpath(dir)
+        src = joinpath(dir, "src")
+        mkpath(src)
+        write(joinpath(src, "index.md"), md_content)
+        run(pipeline(`$(Documenter.git()) -C $dir init --quiet`, stdout = devnull))
+
+        Documenter.makedocs(;
+            sitename = "Test",
+            root = dir,
+            source = "src",
+            build = "build",
+            warnonly = true,
+            remotes = nothing,
+            format = DocumenterVitepress.MarkdownVitepress(
+                repo = "github.com/test/Test.jl",
+                devbranch = "main",
+                devurl = "dev",
+                build_vitepress = false,  # only need the emitted markdown, not the JS build
+                deploy_decision = Documenter.DeployDecision(; all_ok = false),
+            ),
+            pages = ["index.md"],
+        )
+
+        rendered = read(joinpath(dir, "build", ".documenter", "index.md"), String)
+
+        # The colored @repl block is a SINGLE `ansi` fence annotated with a
+        # `julia-repl-runs=` spec (the marker our Shiki transformer keys on).
+        fence = match(r"```ansi julia-repl-runs=(\S+)\n(.*?)\n```"s, rendered)
+        @test fence !== nothing
+        runspec, body = fence.captures
+        # Input prompt and colored output live in the SAME fence (one unified box).
+        @test occursin("julia> Colored()", body)
+        @test occursin("\e[31mred\e[39m", body)
+        # The spec interleaves `julia` (input) and `ansi` (output) runs.
+        @test occursin("julia:", runspec) && occursin("ansi:", runspec)
+
+        # No raw escape codes may leak into a plain `julia` fence (the bug: they
+        # used to be concatenated into a `julia` block and rendered verbatim).
+        for m in eachmatch(r"```julia\n(.*?)\n```"s, rendered)
+            @test !occursin('\e', m.captures[1])
+        end
+
+        # The plain (colorless) @repl block is unchanged: one contiguous `julia`
+        # transcript, with no `julia-repl-runs=` annotation.
+        @test occursin("```julia\njulia> 1 + 1\n2\n```", rendered)
+    end
+end
+
 @testset "noindex injection" begin
     apply_noindex = DocumenterVitepress.apply_noindex
     marker = "// REPLACE_ME_DOCUMENTER_VITEPRESS_NOINDEX"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -225,17 +225,9 @@ end
 end
 
 @testset "REPL block ANSI color output (issue #373)" begin
-    # A `@repl` block whose result's `text/plain` show emits ANSI escape codes
-    # when `:color` is set (as StyledStrings and many colored `show` methods do)
-    # must be emitted as a SINGLE `ansi` fence carrying a `julia-repl-runs=` spec.
-    # Our Shiki transformer uses that spec to render one <pre> with the input
-    # Julia-highlighted and the output ANSI-colored -- rather than concatenating
-    # everything into a `julia` fence where the raw escape codes would show up
-    # verbatim.  A plain `@repl` block must be unaffected and stay a single
-    # contiguous `julia` transcript.
-    #
-    # The markdown is written flush-left on purpose: leading indentation would
-    # turn the ```@repl fences into indented code blocks.
+    # Colored `@repl` output becomes one `ansi` fence with a `julia-repl-runs=`
+    # spec; plain `@repl` stays one `julia` block. Markdown flush-left so the
+    # ```@repl fences aren't indented.
     md_content = raw"""
 # Repl ansi
 
@@ -267,7 +259,7 @@ Colored()
                 repo = "github.com/test/Test.jl",
                 devbranch = "main",
                 devurl = "dev",
-                build_vitepress = false,  # only need the emitted markdown, not the JS build
+                build_vitepress = false,  # only need the emitted markdown
                 deploy_decision = Documenter.DeployDecision(; all_ok = false),
             ),
             pages = ["index.md"],
@@ -275,25 +267,22 @@ Colored()
 
         rendered = read(joinpath(dir, "build", ".documenter", "index.md"), String)
 
-        # The colored @repl block is a SINGLE `ansi` fence annotated with a
-        # `julia-repl-runs=` spec (the marker our Shiki transformer keys on).
+        # Colored block: one `ansi` fence carrying the runs spec.
         fence = match(r"```ansi julia-repl-runs=(\S+)\n(.*?)\n```"s, rendered)
         @test fence !== nothing
         runspec, body = fence.captures
-        # Input prompt and colored output live in the SAME fence (one unified box).
+        # Input prompt and colored output share the one fence.
         @test occursin("julia> Colored()", body)
         @test occursin("\e[31mred\e[39m", body)
-        # The spec interleaves `julia` (input) and `ansi` (output) runs.
+        # Spec interleaves `julia` (input) and `ansi` (output) runs.
         @test occursin("julia:", runspec) && occursin("ansi:", runspec)
 
-        # No raw escape codes may leak into a plain `julia` fence (the bug: they
-        # used to be concatenated into a `julia` block and rendered verbatim).
+        # No escape codes leak into a plain `julia` fence.
         for m in eachmatch(r"```julia\n(.*?)\n```"s, rendered)
             @test !occursin('\e', m.captures[1])
         end
 
-        # The plain (colorless) @repl block is unchanged: one contiguous `julia`
-        # transcript, with no `julia-repl-runs=` annotation.
+        # Colorless block: unchanged single `julia` transcript.
         @test occursin("```julia\njulia> 1 + 1\n2\n```", rendered)
     end
 end


### PR DESCRIPTION
Fixes #373.

## Problem

`@repl` output that carries ANSI escape codes — e.g. from StyledStrings or colored `show` methods — rendered as raw escape sequences (`T4 [33mSpectrum[39m…`) instead of colored text. Adding `writer_supports_ansicolor(::MarkdownVitepress) = true` fixed `@example` blocks but not `@repl`.

The cause was entirely on the DocumenterVitepress side. Documenter already tags `@repl` output as `documenter-ansi` and honors `writer_supports_ansicolor` for both `@example` and `@repl`. But `join_multiblock` handled only its own `@ansi` block (`mcb.language == "ansi"`); for `@repl` (`mcb.language == "julia-repl"`) it concatenated the interleaved input and `documenter-ansi` output into a single `julia` fence, where the escape codes surfaced verbatim.

## Fix

A code fence carries only one Shiki grammar, but Documenter's HTML output shows one box with syntax-highlighted input **and** ANSI-colored output. To match that:

- **`src/writer.jl` (`join_multiblock`)**: when a `@repl` transcript's output actually contains ANSI escapes, emit it as a single `ansi` fence annotated with a `julia-repl-runs=<lang:linecount,…>` spec derived from the child blocks. Colorless `@repl` blocks are unchanged.
- **`template/src/.vitepress/julia-repl-transformer.ts`**: a `code` hook (folded into the existing transformer) reads that spec, re-highlights the input runs as `julia` and the output runs as `ansi`, and stitches the lines into one `<pre>`. Julia runs are re-highlighted through the same transformer, so the existing `repl-prompt` styling still applies; the recursive calls carry empty meta, so the hook is a no-op for them (no infinite recursion).

Degrades gracefully: a customized `.vitepress` without the transformer update still renders the block as one `ansi` box (colored output, non-highlighted input).

## Verification

- New round-trip test in `test/runtests.jl` (colored `@repl` → single `ansi` fence with the runs spec and escapes; plain `@repl` → single `julia` block).
- A full VitePress build with the real transformer and real emitted markdown produces one `<pre>` with Julia-highlighted input (+ `repl-prompt` classes) and ANSI output converted to dual-theme color spans, no raw escapes — including colored error output.

No Documenter change is required.