### PR TITLE
Add `overrides.css` file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Added a `noindex_non_stable` option to `MarkdownVitepress` (default `true`) that injects a `noindex, nofollow` robots meta into non-stable, non-root deployments so search engines only index the stable docs [#361](https://github.com/LuxDL/DocumenterVitepress.jl/pull/361)
 - Interactive `text/html` show output that contains `<script>` tags (e.g. WGLMakie/Bonito figures, Plotly) now actually runs. Such output is wrapped in `<ClientOnly>` (so the potentially-multi-MB widget is not server-rendered) and its scripts are executed on the client via a new `v-exec-scripts` directive, on the initial render and on client-side navigation — previously `v-html` set `innerHTML`, whose `<script>` tags the browser never executes, so figures only appeared on a hard reload. Script-free HTML output keeps the plain server-rendered `v-html` path.
 - Added a GitHub Actions workflow for posting a PR preview comment with a link to the documentation preview. The workflow automatically reads `deploy_repo` from `docs/make.jl` to support cross-repository deployments, and only runs on PRs from the same repository (not forks) [#355](https://github.com/LuxDL/DocumenterVitepress.jl/pull/355)
+- Added an `overrides.css` file to allow for targeted overrides to the default Vitepress and DocumenterVitepress styles without having to copy the entire theme [#379](https://github.com/LuxDL/DocumenterVitepress.jl/pull/379)
 
 ## v0.3.4 - 2026-05-21
 

--- a/docs/src/manual/style_css.md
+++ b/docs/src/manual/style_css.md
@@ -1,27 +1,42 @@
 # CSS Styling
 
-You can customize the appearance of your site by modifying the `style.css` file: 
+DocumenterVitepress contains several CSS files, which all belong in the `docs/src/.vitepress/theme/` folder:
 
 ```
-docs
-└── src
-    └── .vitepress
-        └── theme
-            └── style.css
+MyPackage.jl
+├── CHANGELOG.md
+├── docs
+│   ├── src
+│   │   ├── .vitepress
+│   │   │   └── theme
+│   │   │       ├── style.css
+│   │   │       ├── docstrings.css
+│   │   │       └── overrides.css
+│   │   └── ...
+│   ├── make.jl
+│   └── ...
+└── ...
 ```
+
+If you are happy with DocumenterVitepress's defaults, you do not need to provide these files, as DocumenterVitepress will copy the default CSS files from the package, which can be found here:
+
+- [`style.css`](https://github.com/LuxDL/DocumenterVitepress.jl/blob/main/template/src/.vitepress/theme/style.css)
+- [`docstrings.css`](https://github.com/LuxDL/DocumenterVitepress.jl/blob/main/template/src/.vitepress/theme/docstrings.css)
+- [`overrides.css`](https://github.com/LuxDL/DocumenterVitepress.jl/blob/main/template/src/.vitepress/theme/overrides.css)
+
+However, if you want to customise the appearance of your site, you can provide your own versions of these files.
+
+For small changes it is easiest to modify `overrides.css`, which by default is empty, and is loaded after the other CSS files.
+This lets you apply overrides to the defaults without having to copy the entire `style.css` or `docstrings.css` files.
+
+Note that Vitepress itself also contains a number of style sheets which are not part of DocumenterVitepress (see [the Vitepress docs](https://vitepress.dev/guide/custom-theme) for more info).
+Modifying the style sheets here will also allow you to override the default Vitepress styles if you want to do so.
 
 ## Layout options
 
 For example, the following settings can be adjusted to increase the available space for your content.
 
-::: warning
-
-To restore the default options, copy and paste the `style.css` file into `docs/src/.vitepress/theme/` and delete the following lines:
-
-:::
-
 ```css
-
 .VPDoc.has-aside .content-container {
   max-width: 100% !important;
 }

--- a/docs/src/manual/style_css.md
+++ b/docs/src/manual/style_css.md
@@ -34,7 +34,7 @@ Modifying the style sheets here will also allow you to override the default Vite
 
 ## Layout options
 
-For example, the following settings can be adjusted to increase the available space for your content.
+For example, to increase the available space for your content, you can add the following to `overrides.css`:
 
 ```css
 .VPDoc.has-aside .content-container {
@@ -146,6 +146,25 @@ The following settings allows your content to fill out all available space on sc
 
 ```
 
+## Colors
+
+Vitepress (and thus DocumenterVitepress) use CSS variables to define colors, which can be modified in `overrides.css` to change the color scheme of your site.
+
+For example, the primary text color is `--vp-c-text-1`, which you can set to a different value if desired.
+The colors here correspond to light and dark mode respectively.
+
+```css
+:root {
+    --vp-c-text-1: #000000;
+}
+
+.dark {
+    --vp-c-text-1: #ffffff;
+}
+```
+
+To see a full list of available CSS variables, see [the Vitepress source code](https://github.com/vuejs/vitepress/blob/main/src/client/theme-default/styles/vars.css).
+
 ## More
 
-Other attributes can also be modified there, i.e., text colors, link colors, font family, etc.
+Other attributes can also be modified there, i.e., font family, etc.

--- a/src/vitepress_config.jl
+++ b/src/vitepress_config.jl
@@ -53,19 +53,14 @@ function modify_config_file(doc, settings, deploy_decision, i_folder, base)
         end
     end
 
-    # ? theme / check for index.ts, style.css and docstrings.css files
-    if !isfile(joinpath(source_vitepress_dir, "theme", "index.ts"))
-        @info "DocumenterVitepress: Did not detect `docs/src/.vitepress/theme/index.ts` file. Substituting in the default file."
-        write(joinpath(build_vitepress_dir, "theme", "index.ts"), read(joinpath(template_vitepress_dir, "theme", "index.ts"), String))
+    for f in ("index.ts", "style.css", "docstrings.css", "overrides.css")
+        theme_f = joinpath("theme", f)
+        if !isfile(joinpath(source_vitepress_dir, theme_f))
+            @info "DocumenterVitepress: Did not detect `docs/src/.vitepress/$theme_f` file. Substituting in the default file."
+            write(joinpath(build_vitepress_dir, theme_f), read(joinpath(template_vitepress_dir, theme_f), String))
+        end
     end
-    if !isfile(joinpath(source_vitepress_dir, "theme", "style.css"))
-        @info "DocumenterVitepress: Did not detect `docs/src/.vitepress/theme/style.css` file. Substituting in the default file."
-        write(joinpath(build_vitepress_dir, "theme", "style.css"), read(joinpath(template_vitepress_dir, "theme", "style.css"), String))
-    end
-    if !isfile(joinpath(source_vitepress_dir, "theme", "docstrings.css"))
-        @info "DocumenterVitepress: Did not detect `docs/src/.vitepress/theme/docstrings.css` file. Substituting in the default file."
-        write(joinpath(build_vitepress_dir, "theme", "docstrings.css"), read(joinpath(template_vitepress_dir, "theme", "docstrings.css"), String))
-    end
+
     # Copy SidebarDrawerToggle.vue if user hasn't provided one
     sidebar_toggle_source = joinpath(sourcedir, "components", "SidebarDrawerToggle.vue")
     sidebar_toggle_build = joinpath(builddir, settings.md_output_path, "components", "SidebarDrawerToggle.vue")

--- a/src/vitepress_config.jl
+++ b/src/vitepress_config.jl
@@ -53,7 +53,7 @@ function modify_config_file(doc, settings, deploy_decision, i_folder, base)
         end
     end
 
-    for f in ("index.ts", "style.css", "docstrings.css", "overrides.css")
+    for f in ["index.ts", "style.css", "docstrings.css", "overrides.css"]
         theme_f = joinpath("theme", f)
         if !isfile(joinpath(source_vitepress_dir, theme_f))
             @info "DocumenterVitepress: Did not detect `docs/src/.vitepress/$theme_f` file. Substituting in the default file."

--- a/template/src/.vitepress/theme/index.ts
+++ b/template/src/.vitepress/theme/index.ts
@@ -20,6 +20,7 @@ import { enhanceAppWithTabs } from 'vitepress-plugin-tabs/client'
 import '@nolebase/vitepress-plugin-enhanced-readabilities/client/style.css'
 import './style.css' // You could setup your own, or else a default will be copied.
 import './docstrings.css' // You could setup your own, or else a default will be copied.
+import './overrides.css' // You could setup your own, or else a default will be copied.
 
 // `v-exec-scripts` runs the <script> tags inside a `v-html`'d block: innerHTML never executes
 // scripts, so we re-create each one. `src` scripts are awaited so order holds (bundle before

--- a/template/src/.vitepress/theme/overrides.css
+++ b/template/src/.vitepress/theme/overrides.css
@@ -1,0 +1,2 @@
+/* Override default DocumenterVitepress styles here.
+   This file is loaded after style.css, so rules here take precedence. */


### PR DESCRIPTION
Closes #378 and adds some more docs about styles.

I tested locally and it works as intended. The existing test suite doesn't exercise the styling, so I didn't add a test.