### PR TITLE
Reset code block colour to main text colour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 - Interactive `text/html` show output that contains `<script>` tags (e.g. WGLMakie/Bonito figures, Plotly) now actually runs. Such output is wrapped in `<ClientOnly>` (so the potentially-multi-MB widget is not server-rendered) and its scripts are executed on the client via a new `v-exec-scripts` directive, on the initial render and on client-side navigation — previously `v-html` set `innerHTML`, whose `<script>` tags the browser never executes, so figures only appeared on a hard reload. Script-free HTML output keeps the plain server-rendered `v-html` path.
 - Added a GitHub Actions workflow for posting a PR preview comment with a link to the documentation preview. The workflow automatically reads `deploy_repo` from `docs/make.jl` to support cross-repository deployments, and only runs on PRs from the same repository (not forks) [#355](https://github.com/LuxDL/DocumenterVitepress.jl/pull/355)
 - Added an `overrides.css` file to allow for targeted overrides to the default Vitepress and DocumenterVitepress styles without having to copy the entire theme [#379](https://github.com/LuxDL/DocumenterVitepress.jl/pull/379)
+- Fixed a bug where DocumenterVitepress would error if outside of a git repository [#380](https://github.com/LuxDL/DocumenterVitepress.jl/pull/380)
+- Changed the default text colour for code blocks to be the same as plain text, to avoid confusion with hyperlinks [#380](https://github.com/LuxDL/DocumenterVitepress.jl/pull/380)
 
 ## v0.3.4 - 2026-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Interactive `text/html` show output that contains `<script>` tags (e.g. WGLMakie/Bonito figures, Plotly) now actually runs. Such output is wrapped in `<ClientOnly>` (so the potentially-multi-MB widget is not server-rendered) and its scripts are executed on the client via a new `v-exec-scripts` directive, on the initial render and on client-side navigation — previously `v-html` set `innerHTML`, whose `<script>` tags the browser never executes, so figures only appeared on a hard reload. Script-free HTML output keeps the plain server-rendered `v-html` path.
 - Added a GitHub Actions workflow for posting a PR preview comment with a link to the documentation preview. The workflow automatically reads `deploy_repo` from `docs/make.jl` to support cross-repository deployments, and only runs on PRs from the same repository (not forks) [#355](https://github.com/LuxDL/DocumenterVitepress.jl/pull/355)
 - Added an `overrides.css` file to allow for targeted overrides to the default Vitepress and DocumenterVitepress styles without having to copy the entire theme [#379](https://github.com/LuxDL/DocumenterVitepress.jl/pull/379)
-- Fixed a bug where DocumenterVitepress would error if outside of a git repository [#380](https://github.com/LuxDL/DocumenterVitepress.jl/pull/380)
+- Fixed a bug where DocumenterVitepress would error if outside of a git repository
 - Changed the default text colour for code blocks to be the same as plain text, to avoid confusion with hyperlinks [#380](https://github.com/LuxDL/DocumenterVitepress.jl/pull/380)
 
 ## v0.3.4 - 2026-05-21

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -537,7 +537,13 @@ end
 stripped_version(v::VersionNumber) = VersionNumber(v.major, v.minor, v.patch)
 
 function get_all_tagged_release_versions()::Vector{VersionNumber}
-    tags = readlines(`$(Documenter.git()) tag`)
+    tags = try
+        readlines(`$(Documenter.git()) tag`)
+    catch e
+        e isa ProcessFailedException || rethrow(e)
+        @info "DocumenterVitepress: could not get git tags, assuming no tagged releases exist."
+        return VersionNumber[]
+    end
     version_numbers = stripped_version.(VersionNumber.(filter(is_version_string, tags)))
     filter!(version_numbers) do v
         isempty(v.prerelease) # we never want alias bases for prereleases so we don't clobber `stable` etc.

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -540,7 +540,7 @@ function get_all_tagged_release_versions()::Vector{VersionNumber}
     tags = try
         readlines(`$(Documenter.git()) tag`)
     catch e
-        e isa ProcessFailedException || rethrow(e)
+        (e isa ProcessFailedException || e isa Base.IOError) || rethrow(e)
         @info "DocumenterVitepress: could not get git tags, assuming no tagged releases exist."
         return VersionNumber[]
     end

--- a/template/src/.vitepress/theme/style.css
+++ b/template/src/.vitepress/theme/style.css
@@ -78,6 +78,19 @@ font-feature-settings: "calt" off;
   --vp-custom-block-tip-bg: var(--vp-tip-bg);
 }
 
+ /* Reset text color of code blocks to default text color
+  * Vitepress uses --vp-c-brand-1 by default, which makes code look like links (#377) */
+:root {
+  --vp-code-color: var(--vp-c-text-1);
+}
+.custom-block.tip code {
+  color: var(--vp-c-text-1);
+  background-color: var(--vp-code-bg);
+}
+.custom-block.tip a>code {
+  color:var(--vp-c-tip-1);
+}
+
  /* Component: Button */
 :root {
   --vp-button-brand-border: var(--vp-light-gray);


### PR DESCRIPTION
This closes #377.

Here are some screenshots of before/after as requested :)

## `index.md`

```markdown
# Colours PR (before|after)

This is `some code`. This is [`code that is a link`](https://example.com). This is [a link](https://example.com).

!!! note "A note"
    This is `some code`. This is [`code that is a link`](https://example.com). This is [a link](https://example.com).
```

## light mode


<img width="710" height="207" alt="Screenshot 2026-07-13 at 18 45 31" src="https://github.com/user-attachments/assets/ca0ca0ea-c3da-49af-8217-8c182a4f3ec0" />
<img width="710" height="207" alt="Screenshot 2026-07-13 at 18 45 04" src="https://github.com/user-attachments/assets/19527265-13b3-4b51-add0-71268907cc2b" />

## dark mode

<img width="710" height="207" alt="Screenshot 2026-07-13 at 18 45 34" src="https://github.com/user-attachments/assets/1fd31c65-fb91-4cf6-b7dc-dffa6840973f" />
<img width="710" height="207" alt="Screenshot 2026-07-13 at 18 45 09" src="https://github.com/user-attachments/assets/7713c420-ff4e-4a6f-818f-3d34c23247ec" />
