### PR TITLE
DecomposeInSidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## unreleased
 
+- Fixed `DecomposeInSidebar` to properly handle mixed lists of decomposed and regular page entries [#381](https://github.com/LuxDL/DocumenterVitepress.jl/pull/381)
+- Changed the default text colour for code blocks to be the same as plain text, to avoid confusion with hyperlinks [#380](https://github.com/LuxDL/DocumenterVitepress.jl/pull/380)
+- Added an `overrides.css` file to allow for targeted overrides to the default Vitepress and DocumenterVitepress styles without having to copy the entire theme [#379](https://github.com/LuxDL/DocumenterVitepress.jl/pull/379)
+- Fixed a bug where DocumenterVitepress would error if outside of a git repository
 - Fixed ANSI-colored `@repl` output (e.g. from StyledStrings or colored `show` methods) rendering as raw escape codes. `@repl` output whose text carries ANSI escapes is now emitted as a single `ansi` fence annotated with a `julia-repl-runs=` spec, and the `julia-repl-transformer` re-highlights the input as `julia` and the output as `ansi` into one `<pre>` — matching Documenter's HTML output (syntax-highlighted input, colored output in one box). Colorless `@repl` blocks are unchanged [#373](https://github.com/LuxDL/DocumenterVitepress.jl/issues/373)
 - Fixed missing root `index.html` redirect on deploy: `Documenter.deploydocs` writes this for its standard `versions=` argument, but `DocumenterVitepress.deploydocs` uses a custom `versions` type that bypasses that code path, so a freshly-deployed site had nothing at its root and 404'd instead of redirecting to `stable`/`dev` [#368](https://github.com/LuxDL/DocumenterVitepress.jl/pull/368)
 - Made sidebar/navbar generation overloadable: `pagelist2str` now dispatches on a `Val{:sidebar}`/`Val{:navbar}` tag (with a `get_title` helper), so a custom `make.jl` can control how pages map to VitePress nav entries [#357](https://github.com/LuxDL/DocumenterVitepress.jl/pull/357)
@@ -13,9 +17,6 @@
 - Added a `noindex_non_stable` option to `MarkdownVitepress` (default `true`) that injects a `noindex, nofollow` robots meta into non-stable, non-root deployments so search engines only index the stable docs [#361](https://github.com/LuxDL/DocumenterVitepress.jl/pull/361)
 - Interactive `text/html` show output that contains `<script>` tags (e.g. WGLMakie/Bonito figures, Plotly) now actually runs. Such output is wrapped in `<ClientOnly>` (so the potentially-multi-MB widget is not server-rendered) and its scripts are executed on the client via a new `v-exec-scripts` directive, on the initial render and on client-side navigation — previously `v-html` set `innerHTML`, whose `<script>` tags the browser never executes, so figures only appeared on a hard reload. Script-free HTML output keeps the plain server-rendered `v-html` path.
 - Added a GitHub Actions workflow for posting a PR preview comment with a link to the documentation preview. The workflow automatically reads `deploy_repo` from `docs/make.jl` to support cross-repository deployments, and only runs on PRs from the same repository (not forks) [#355](https://github.com/LuxDL/DocumenterVitepress.jl/pull/355)
-- Added an `overrides.css` file to allow for targeted overrides to the default Vitepress and DocumenterVitepress styles without having to copy the entire theme [#379](https://github.com/LuxDL/DocumenterVitepress.jl/pull/379)
-- Fixed a bug where DocumenterVitepress would error if outside of a git repository
-- Changed the default text colour for code blocks to be the same as plain text, to avoid confusion with hyperlinks [#380](https://github.com/LuxDL/DocumenterVitepress.jl/pull/380)
 
 ## v0.3.4 - 2026-05-21
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,43 +1,9 @@
 using Documenter
 using DocumenterVitepress
+using DocumenterVitepress: DecomposeInSidebar
 using DocumenterCitations
 using DocumenterInterLinks
 using LaTeXStrings
-
-struct DecomposeInSidebar
-    path::String
-    pages::Any
-end
-
-# NOTE: overrides pagelist2str globally; works once per Julia session.
-function DocumenterVitepress.pagelist2str(doc, ds::Vector{<: Any}, ::Val{:sidebar})
-    if !all(x -> x isa DecomposeInSidebar, ds)
-        return invoke(pagelist2str, Tuple{Any, Any, Val{:sidebar}}, doc, ds, Val(:sidebar))
-    end
-    contents = DocumenterVitepress.pagelist2str.((doc,), ds, (Val(:sidebar),))
-    ret = "{\n" * join(contents, ",\n") * "\n}"
-    return ret
-end
-
-function DocumenterVitepress.pagelist2str(doc, ds::DecomposeInSidebar, ::Val{:sidebar})
-    raw_contents = DocumenterVitepress.pagelist2str(doc, ds.pages, Val(:sidebar))
-    contents = if raw_contents isa String
-        raw_contents
-    else
-        join(raw_contents, ",\n")
-    end
-
-    return "\"/$(ds.path)/\": {\n$(contents)\n}"
-end
-
-function DocumenterVitepress.pagelist2str(doc, ds::DecomposeInSidebar, ::Val{:navbar})
-    return DocumenterVitepress.pagelist2str(doc, ds.pages, Val(:sidebar))
-end
-
-function Documenter.walk_navpages(ds::DecomposeInSidebar, parent, doc)
-    return Documenter.walk_navpages(ds.pages, parent, doc)
-end
-
 
 # Handle DocumenterCitations integration - if you're running this, then you don't need anything here!!
 documenter_citations_dir = dirname(dirname(pathof(DocumenterCitations)))
@@ -101,10 +67,11 @@ makedocs(;
             "Authors' badge" => "manual/author_badge.md",
             "GitHub Icon with Stars" => "manual/repo_stars.md",
         ]),
-        DecomposeInSidebar("devs", "Developers' documentation" => [
+        "Developers' documentation" => [
             "The rendering process" => "devs/render_pipeline.md",
             "Internal API" => "devs/internal_api.md",
-        ]),
+        ],
+        "api.md",
     ],
     plugins = [bib, links],
 )

--- a/src/vitepress_config.jl
+++ b/src/vitepress_config.jl
@@ -365,3 +365,58 @@ end
 function _get_first_or_string(x)
     return first(x)
 end
+
+"""
+    DecomposeInSidebar(path::String, pages)
+
+A wrapper for a collection of pages that allows for multi-sidebar configurations in Vitepress. 
+
+When you pass a list of `DecomposeInSidebar` objects to the `pages` argument of `makedocs`,
+DocumenterVitepress will generate a sidebar configuration that maps different sidebars to 
+different routes. `path` should be the URL path prefix (e.g., `"guide"` or `"manual"`), and 
+`pages` should be the standard Documenter page list for that section.
+"""
+struct DecomposeInSidebar
+    path::String
+    pages::Any
+end
+
+function pagelist2str(doc, ds::Vector{<: Any}, ::Val{:sidebar})
+    if !any(x -> x isa DecomposeInSidebar, ds)
+        return invoke(pagelist2str, Tuple{Any, Any, Val{:sidebar}}, doc, ds, Val(:sidebar))
+    end
+    
+    decomposed_items = filter(x -> x isa DecomposeInSidebar, ds)
+    regular_items = filter(x -> !(x isa DecomposeInSidebar), ds)
+    
+    contents = String[]
+    for x in decomposed_items
+        push!(contents, pagelist2str(doc, x, Val(:sidebar)))
+    end
+    
+    if !isempty(regular_items)
+        raw_regular = invoke(pagelist2str, Tuple{Any, Any, Val{:sidebar}}, doc, regular_items, Val(:sidebar))
+        push!(contents, "\"/\": " * raw_regular)
+    end
+    
+    return "{\n" * join(contents, ",\n") * "\n}"
+end
+
+function pagelist2str(doc, ds::DecomposeInSidebar, ::Val{:sidebar})
+    raw_contents = pagelist2str(doc, ds.pages, Val(:sidebar))
+    contents = if raw_contents isa String
+        raw_contents
+    else
+        join(raw_contents, ",\n")
+    end
+
+    return "\"/$(ds.path)/\": {\n$(contents)\n}"
+end
+
+function pagelist2str(doc, ds::DecomposeInSidebar, ::Val{:navbar})
+    return pagelist2str(doc, ds.pages, Val(:sidebar))
+end
+
+function Documenter.walk_navpages(ds::DecomposeInSidebar, parent, doc)
+    return Documenter.walk_navpages(ds.pages, parent, doc)
+end

--- a/src/vitepress_config.jl
+++ b/src/vitepress_config.jl
@@ -404,17 +404,38 @@ end
 
 function pagelist2str(doc, ds::DecomposeInSidebar, ::Val{:sidebar})
     raw_contents = pagelist2str(doc, ds.pages, Val(:sidebar))
-    contents = if raw_contents isa String
-        raw_contents
+    
+    if startswith(raw_contents, "[")
+        return "\"/$(ds.path)/\": $(raw_contents)"
     else
-        join(raw_contents, ",\n")
+        return "\"/$(ds.path)/\": [\n{\n$(raw_contents)\n}\n]"
     end
-
-    return "\"/$(ds.path)/\": {\n$(contents)\n}"
 end
 
 function pagelist2str(doc, ds::DecomposeInSidebar, ::Val{:navbar})
     return pagelist2str(doc, ds.pages, Val(:sidebar))
+end
+
+function pagelist2str(doc, ds::Vector{<: Any}, ::Val{:navbar})
+    if !any(x -> x isa DecomposeInSidebar, ds)
+        return invoke(pagelist2str, Tuple{Any, Any, Val{:navbar}}, doc, ds, Val(:navbar))
+    end
+
+    contents = String[]
+    for x in ds
+        if x isa DecomposeInSidebar
+            # Expand vectors, otherwise treat as single item
+            items = x.pages isa AbstractVector ? x.pages : [x.pages]
+            for p in items
+                str = pagelist2str(doc, p, Val(:sidebar))
+                isempty(str) || push!(contents, "{ " * str * " }")
+            end
+        else
+            str = pagelist2str(doc, x, Val(:navbar))
+            isempty(str) || push!(contents, "{ " * str * " }")
+        end
+    end
+    return "[" * join(contents, ",\n") * "]"
 end
 
 function Documenter.walk_navpages(ds::DecomposeInSidebar, parent, doc)


### PR DESCRIPTION
Moved this into DVpress and modified it such that we can have mixed lists. Normal Documenter pages + DecomposeInSidebar behaviour if used. 

`api.md` was gone, I put it back. 

@asinghvi17 