### PR TITLE
documenter search.js rules into vue component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ docs/.vitepress/dist
 docs/.DS_Store
 docs/package-lock.json
 .qodo
+dev/

--- a/docs/src/.vitepress/config.mts
+++ b/docs/src/.vitepress/config.mts
@@ -41,7 +41,8 @@ export default defineConfig({
     ['link', { rel: 'icon', href: 'REPLACE_ME_DOCUMENTER_VITEPRESS_FAVICON' }],
     ['script', {src: `${getBaseRepository(baseTemp.base)}versions.js`}],
     // ['script', {src: '/versions.js'], for custom domains, I guess if deploy_url is available.
-    ['script', {src: `${baseTemp.base}siteinfo.js`}]
+    ['script', {src: `${baseTemp.base}siteinfo.js`}],
+    ['script', {src: `${baseTemp.base}documenter_search_index.js`}]
   ],
    markdown: {
     codeTransformers: [juliaReplTransformer()],
@@ -89,12 +90,12 @@ export default defineConfig({
     outline: 'deep',
     // https://vitepress.dev/reference/default-theme-config
     logo: 'REPLACE_ME_DOCUMENTER_VITEPRESS',
-    search: {
-      provider: 'local',
-      options: {
-        detailedView: true
-      }
-    },
+    // search: {
+    //   provider: 'local',
+    //   options: {
+    //     detailedView: true
+    //   }
+    // },
     nav,
     sidebar: 'REPLACE_ME_DOCUMENTER_VITEPRESS',
     sidebarDrawer: 'REPLACE_ME_DOCUMENTER_VITEPRESS_SIDEBAR_DRAWER',

--- a/docs/src/.vitepress/theme/index.ts
+++ b/docs/src/.vitepress/theme/index.ts
@@ -15,6 +15,7 @@ import StarUs from '@/StarUs.vue'
 import AuthorBadge from '@/AuthorBadge.vue'
 import Authors from '@/Authors.vue'
 import SidebarDrawerToggle from '@/SidebarDrawerToggle.vue'
+import DocumenterSearch from '@/DocumenterSearch.vue'
 import { enhanceAppWithTabs } from 'vitepress-plugin-tabs/client'
 
 import '@nolebase/vitepress-plugin-enhanced-readabilities/client/style.css'
@@ -33,7 +34,10 @@ export const Theme: ThemeConfig = {
       // A enhanced readabilities menu for narrower screens (usually smaller than iPad Mini)
       'nav-screen-content-after': () => h(NolebaseEnhancedReadabilitiesScreenMenu),
       // Sidebar drawer toggle button (to the left of search bar)
-      'nav-bar-content-before': () => h(SidebarDrawerToggle),
+      'nav-bar-content-before': () => [
+        h(SidebarDrawerToggle),
+        h(DocumenterSearch)
+      ],
     })
   },
   enhanceApp({ app, router, siteData }) {

--- a/docs/src/components/DocumenterSearch.vue
+++ b/docs/src/components/DocumenterSearch.vue
@@ -37,12 +37,18 @@
                 <line x1="6" y1="6" x2="18" y2="18"></line>
               </svg>
             </button>
-            <button @click="showFilters = !showFilters" class="filter-toggle-btn" title="Toggle Filters" style="margin-right: 8px;">
+            <button @click="showFilters = !showFilters" class="filter-toggle-btn" title="Toggle Filters">
               <svg v-if="!showFilters" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"></polygon>
               </svg>
               <svg v-else xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <line x1="4" y1="21" x2="4" y2="14"></line><line x1="4" y1="10" x2="4" y2="3"></line><line x1="12" y1="21" x2="12" y2="12"></line><line x1="12" y1="8" x2="12" y2="3"></line><line x1="20" y1="21" x2="20" y2="16"></line><line x1="20" y1="12" x2="20" y2="3"></line><line x1="1" y1="14" x2="7" y2="14"></line><line x1="9" y1="8" x2="15" y2="8"></line><line x1="17" y1="16" x2="23" y2="16"></line>
+              </svg>
+            </button>
+            <button @click="isCollected = !isCollected" class="filter-toggle-btn" :class="{ 'sort-toggle-active': isCollected }" title="Group by page" style="margin-right: 8px;">
+              <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <rect x="2" y="7" width="20" height="14" rx="2" ry="2"></rect>
+                <path d="M16 2H8l-2 5h12L16 2z"></path>
               </svg>
             </button>
             <button class="close-btn" @click="isOpen = false">Esc</button>
@@ -57,7 +63,8 @@
             
             <div v-else>
               <!-- Filters -->
-              <div v-show="showFilters" class="is-flex gap-2 is-flex-wrap-wrap is-justify-content-flex-start is-align-items-center search-filters" style="margin-bottom: 12px;">
+              <div v-show="showFilters" class="search-toolbar">
+                <div class="search-toolbar-group">
                   <button 
                     class="search-filter"
                     :class="{ 'search-filter-selected': selectedFilter === '' }"
@@ -75,6 +82,7 @@
                     {{ filter }} <span class="filter-badge">{{ categoryCounts[filter.toLowerCase()] || 0 }}</span>
                   </button>
                 </div>
+              </div>
               
               <div class="search-divider" v-show="showFilters"></div>
               
@@ -88,6 +96,32 @@
                 No result found!
               </div>
 
+              <!-- Grouped (Collect) view -->
+              <div v-else-if="isCollected" class="is-clipped w-100 is-flex is-flex-direction-column has-text-justified mt-1" @click="handleResultClick">
+                <div v-for="group in groupedResults" :key="group.pagePath" class="search-group">
+                  <div class="search-group-header">
+                    <div class="search-group-breadcrumbs">
+                      <template v-for="(crumb, ci) in group.breadcrumbs" :key="ci">
+                        <span v-if="ci > 0" class="breadcrumb-sep">&gt;</span>
+                        <span>{{ crumb }}</span>
+                      </template>
+                    </div>
+                    <div class="search-group-title">{{ group.pageTitle }}</div>
+                  </div>
+                  <div class="search-group-children">
+                    <div 
+                      v-for="result in group.results" 
+                      :key="result.location" 
+                      class="search-result-wrapper"
+                      :class="{ 'is-selected': result._flatIndex === selectedIndex }"
+                      @mouseenter="selectedIndex = result._flatIndex"
+                      v-html="result.div"
+                    ></div>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Flat view (default or Sort A-Z) -->
               <div v-else class="is-clipped w-100 is-flex is-flex-direction-column gap-2 has-text-justified mt-1" @click="handleResultClick">
                 <div 
                   v-for="(result, index) in filteredResults" 
@@ -112,6 +146,7 @@ import { ref, computed, onMounted, onUnmounted, watch, nextTick } from 'vue';
 
 const isOpen = ref(false);
 const showFilters = ref(true);
+const isCollected = ref(false);
 const searchQuery = ref('');
 const searchInputRef = ref(null);
 const selectedFilter = ref('');
@@ -119,6 +154,7 @@ const availableFilters = ref([]);
 const unfilteredResults = ref([]);
 const isWorkerRunning = ref(false);
 const selectedIndex = ref(-1);
+
 let lastSearchText = '';
 let worker = null;
 let checkInterval = null;
@@ -181,7 +217,35 @@ const filteredResults = computed(() => {
       links.add(res.location);
     }
   }
+
   return final_results;
+});
+
+// Grouped results for Collect mode
+const groupedResults = computed(() => {
+  const groups = new Map();
+  let flatIndex = 0;
+  
+  for (const result of filteredResults.value) {
+    const pagePath = result.location.split('#')[0];
+    if (!groups.has(pagePath)) {
+      // Build breadcrumbs from the path segments
+      const segments = pagePath.replace(/\.[^.]+$/, '').split('/');
+      const breadcrumbs = segments.map(s => 
+        s.replace(/[-_]/g, ' ').replace(/\b\w/g, c => c.toUpperCase())
+      );
+      groups.set(pagePath, {
+        pagePath,
+        pageTitle: result.page || breadcrumbs[breadcrumbs.length - 1] || pagePath,
+        breadcrumbs,
+        results: [],
+      });
+    }
+    const r = { ...result, _flatIndex: flatIndex++ };
+    groups.get(pagePath).results.push(r);
+  }
+  
+  return Array.from(groups.values());
 });
 
 // Calculate counts per category based on current unfiltered results
@@ -404,6 +468,8 @@ function initWorker() {
                   filtered_results.push({
                     location: result.location,
                     category: cat,
+                    title: result.title || '',
+                    page: result.page || '',
                     div: make_search_result(result, query),
                   });
                 }
@@ -577,13 +643,22 @@ function initWorker() {
   overflow-y: auto;
 }
 
-/* Filters */
-.search-filters {
+/* Toolbar (Filters + Sorting) */
+.search-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.search-toolbar-group {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
   align-items: center;
 }
+
 
 .filter-toggle-btn {
   background: transparent;
@@ -600,6 +675,10 @@ function initWorker() {
 
 .filter-toggle-btn:hover {
   background: var(--vp-c-bg-alt);
+  color: var(--vp-c-brand-1);
+}
+
+.sort-toggle-active {
   color: var(--vp-c-brand-1);
 }
 
@@ -717,6 +796,63 @@ function initWorker() {
   color: var(--vp-c-text-3);
   margin-bottom: 4px;
   font-weight: 500;
+}
+
+/* Grouped / Collect view */
+.search-group {
+  margin-bottom: 4px;
+}
+
+.search-group-header {
+  background: var(--vp-c-bg-alt);
+  padding: 10px 14px;
+  border-radius: 8px 8px 0 0;
+}
+
+.search-group-breadcrumbs {
+  font-size: 0.75rem;
+  color: var(--vp-c-text-3);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-bottom: 2px;
+}
+
+.breadcrumb-sep {
+  font-size: 0.65rem;
+  color: var(--vp-c-text-3);
+  opacity: 0.6;
+}
+
+.search-group-title {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--vp-c-text-1);
+}
+
+.search-group-children {
+  border-left: 2px solid var(--vp-c-divider);
+  margin-left: 14px;
+  padding-left: 2px;
+}
+
+.search-group-children :deep(.search-result-body),
+.search-group-children :deep(.search-result-loc) {
+  display: none;
+}
+
+.search-group-children :deep(.search-result-link) {
+  padding: 4px 10px;
+}
+
+.search-group-children :deep(.search-result-header) {
+  margin-bottom: 0;
+}
+
+.search-group-children :deep(.search-result-title) {
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--vp-c-text-2);
 }
 
 /* Bulma compatibility utilities for VitePress */

--- a/docs/src/components/DocumenterSearch.vue
+++ b/docs/src/components/DocumenterSearch.vue
@@ -210,9 +210,7 @@ function initWorker() {
       const categories = [...new Set(index.map(x => x.category))];
       availableFilters.value = categories;
       
-      const baseURL = typeof __DEPLOY_ABSPATH__ !== 'undefined' && __DEPLOY_ABSPATH__ !== '' 
-        ? __DEPLOY_ABSPATH__ 
-        : import.meta.env.BASE_URL;
+      const baseURL = import.meta.env.BASE_URL;
       
       const workerFunction = `
         function worker_function() {
@@ -300,7 +298,7 @@ function initWorker() {
             finalUrl = finalUrl.replace(/\\/\\//g, '/').replace('http:/', 'http://').replace('https:/', 'https://');
 
             return \`
-              <a href="\${encodeURI(finalUrl)}" class="search-result-link px-4 py-2">
+              <a href="\${finalUrl}" class="search-result-link px-4 py-2">
                 <div class="search-result-header">
                   <div class="search-result-title \${titleClass}">\${escape(result.title)}</div>
                   <div class="property-search-result-badge">\${result.category}</div>

--- a/docs/src/components/DocumenterSearch.vue
+++ b/docs/src/components/DocumenterSearch.vue
@@ -27,7 +27,16 @@
               placeholder="Search docs" 
               @input="onInput"
               @keydown.esc="isOpen = false"
+              @keydown.down.prevent="navigateDown"
+              @keydown.up.prevent="navigateUp"
+              @keydown.enter.prevent="navigateEnter"
             />
+            <button v-show="searchQuery.length > 0" @click="clearSearch" class="clear-input-btn" title="Clear Search">
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <line x1="18" y1="6" x2="6" y2="18"></line>
+                <line x1="6" y1="6" x2="18" y2="18"></line>
+              </svg>
+            </button>
             <button @click="showFilters = !showFilters" class="filter-toggle-btn" title="Toggle Filters" style="margin-right: 8px;">
               <svg v-if="!showFilters" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"></polygon>
@@ -80,7 +89,14 @@
               </div>
 
               <div v-else class="is-clipped w-100 is-flex is-flex-direction-column gap-2 has-text-justified mt-1" @click="handleResultClick">
-                <div v-for="result in filteredResults" :key="result.location" v-html="result.div"></div>
+                <div 
+                  v-for="(result, index) in filteredResults" 
+                  :key="result.location" 
+                  class="search-result-wrapper"
+                  :class="{ 'is-selected': index === selectedIndex }"
+                  @mouseenter="selectedIndex = index"
+                  v-html="result.div"
+                ></div>
               </div>
             </div>
             
@@ -102,9 +118,51 @@ const selectedFilter = ref('');
 const availableFilters = ref([]);
 const unfilteredResults = ref([]);
 const isWorkerRunning = ref(false);
+const selectedIndex = ref(-1);
 let lastSearchText = '';
 let worker = null;
 let checkInterval = null;
+
+function clearSearch() {
+  searchQuery.value = '';
+  onInput();
+  nextTick(() => {
+    searchInputRef.value?.focus();
+  });
+}
+
+function navigateDown() {
+  if (filteredResults.value.length > 0) {
+    selectedIndex.value = Math.min(selectedIndex.value + 1, filteredResults.value.length - 1);
+    scrollToSelected();
+  }
+}
+
+function navigateUp() {
+  if (filteredResults.value.length > 0) {
+    selectedIndex.value = Math.max(selectedIndex.value - 1, 0);
+    scrollToSelected();
+  }
+}
+
+function navigateEnter() {
+  if (selectedIndex.value >= 0 && selectedIndex.value < filteredResults.value.length) {
+    const el = document.querySelectorAll('.search-result-wrapper')[selectedIndex.value];
+    const link = el?.querySelector('a');
+    if (link) {
+      link.click();
+    }
+  }
+}
+
+function scrollToSelected() {
+  nextTick(() => {
+    const el = document.querySelectorAll('.search-result-wrapper')[selectedIndex.value];
+    if (el) {
+      el.scrollIntoView({ block: 'nearest' });
+    }
+  });
+}
 
 // The filtered results computed on the frontend
 const filteredResults = computed(() => {
@@ -143,6 +201,11 @@ watch(isOpen, (newVal) => {
       searchInputRef.value?.focus();
     });
   }
+});
+
+// Reset selection when results change
+watch(filteredResults, () => {
+  selectedIndex.value = -1;
 });
 
 // Toggle a filter
@@ -491,6 +554,24 @@ function initWorker() {
   cursor: pointer;
 }
 
+.clear-input-btn {
+  background: transparent;
+  border: none;
+  color: var(--vp-c-text-3);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px;
+  border-radius: 50%;
+  margin-right: 4px;
+  transition: color 0.2s, background 0.2s;
+}
+.clear-input-btn:hover {
+  color: var(--vp-c-text-1);
+  background: var(--vp-c-bg-alt);
+}
+
 .search-modal-card-body {
   padding: 20px;
   overflow-y: auto;
@@ -580,11 +661,13 @@ function initWorker() {
   text-decoration: none !important;
   padding: 12px;
   border-radius: 8px;
-  transition: background 0.2s;
+  border: 1px solid transparent;
+  transition: background 0.2s, border-color 0.2s;
   color: inherit;
 }
-:deep(.search-result-link:hover) {
+.search-result-wrapper.is-selected :deep(.search-result-link) {
   background: var(--vp-c-bg-alt);
+  border-color: var(--vp-c-brand-1);
 }
 
 :deep(.search-result-header) {

--- a/docs/src/components/DocumenterSearch.vue
+++ b/docs/src/components/DocumenterSearch.vue
@@ -37,7 +37,7 @@
                 <line x1="6" y1="6" x2="18" y2="18"></line>
               </svg>
             </button>
-            <button @click="showFilters = !showFilters" class="filter-toggle-btn" title="Toggle Filters">
+            <button @click="toggleFiltersVisibility" class="filter-toggle-btn" title="Toggle Filters">
               <svg v-if="!showFilters" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"></polygon>
               </svg>
@@ -45,7 +45,7 @@
                 <line x1="4" y1="21" x2="4" y2="14"></line><line x1="4" y1="10" x2="4" y2="3"></line><line x1="12" y1="21" x2="12" y2="12"></line><line x1="12" y1="8" x2="12" y2="3"></line><line x1="20" y1="21" x2="20" y2="16"></line><line x1="20" y1="12" x2="20" y2="3"></line><line x1="1" y1="14" x2="7" y2="14"></line><line x1="9" y1="8" x2="15" y2="8"></line><line x1="17" y1="16" x2="23" y2="16"></line>
               </svg>
             </button>
-            <button @click="isCollected = !isCollected" class="filter-toggle-btn" :class="{ 'sort-toggle-active': isCollected }" title="Group by page" style="margin-right: 8px;">
+            <button @click="toggleCollected" class="filter-toggle-btn" :class="{ 'sort-toggle-active': isCollected }" title="Group by page" style="margin-right: 8px;">
               <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <rect x="2" y="7" width="20" height="14" rx="2" ry="2"></rect>
                 <path d="M16 2H8l-2 5h12L16 2z"></path>
@@ -97,7 +97,7 @@
               </div>
 
               <!-- Grouped (Collect) view -->
-              <div v-else-if="isCollected" class="is-clipped w-100 is-flex is-flex-direction-column has-text-justified mt-1" @click="handleResultClick">
+              <div v-else-if="isCollected" class="is-clipped w-100 is-flex is-flex-direction-column has-text-justified mt-1" @click="handleResultClick" @mousemove="onMouseMove">
                 <div v-for="group in groupedResults" :key="group.pagePath" class="search-group">
                   <div class="search-group-header">
                     <div class="search-group-breadcrumbs">
@@ -114,7 +114,7 @@
                       :key="result.location" 
                       class="search-result-wrapper"
                       :class="{ 'is-selected': result._flatIndex === selectedIndex }"
-                      @mouseenter="selectedIndex = result._flatIndex"
+                      @mouseenter="onResultHover(result._flatIndex)"
                       v-html="result.div"
                     ></div>
                   </div>
@@ -122,13 +122,13 @@
               </div>
 
               <!-- Flat view (default or Sort A-Z) -->
-              <div v-else class="is-clipped w-100 is-flex is-flex-direction-column gap-2 has-text-justified mt-1" @click="handleResultClick">
+              <div v-else class="is-clipped w-100 is-flex is-flex-direction-column gap-2 has-text-justified mt-1" @click="handleResultClick" @mousemove="onMouseMove">
                 <div 
                   v-for="(result, index) in filteredResults" 
                   :key="result.location" 
                   class="search-result-wrapper"
                   :class="{ 'is-selected': index === selectedIndex }"
-                  @mouseenter="selectedIndex = index"
+                  @mouseenter="onResultHover(index)"
                   v-html="result.div"
                 ></div>
               </div>
@@ -167,8 +167,11 @@ function clearSearch() {
   });
 }
 
+let isKeyboardNav = false;
+
 function navigateDown() {
   if (filteredResults.value.length > 0) {
+    isKeyboardNav = true;
     selectedIndex.value = Math.min(selectedIndex.value + 1, filteredResults.value.length - 1);
     scrollToSelected();
   }
@@ -176,6 +179,7 @@ function navigateDown() {
 
 function navigateUp() {
   if (filteredResults.value.length > 0) {
+    isKeyboardNav = true;
     selectedIndex.value = Math.max(selectedIndex.value - 1, 0);
     scrollToSelected();
   }
@@ -198,6 +202,16 @@ function scrollToSelected() {
       el.scrollIntoView({ block: 'nearest' });
     }
   });
+}
+
+function onResultHover(index) {
+  if (!isKeyboardNav) {
+    selectedIndex.value = index;
+  }
+}
+
+function onMouseMove() {
+  isKeyboardNav = false;
 }
 
 // The filtered results computed on the frontend
@@ -224,28 +238,18 @@ const filteredResults = computed(() => {
 // Grouped results for Collect mode
 const groupedResults = computed(() => {
   const groups = new Map();
-  let flatIndex = 0;
-  
-  for (const result of filteredResults.value) {
-    const pagePath = result.location.split('#')[0];
+  filteredResults.value.forEach(r => {
+    const pagePath = r.location.split('#')[0];
     if (!groups.has(pagePath)) {
-      // Build breadcrumbs from the path segments
-      const segments = pagePath.replace(/\.[^.]+$/, '').split('/');
-      const breadcrumbs = segments.map(s => 
-        s.replace(/[-_]/g, ' ').replace(/\b\w/g, c => c.toUpperCase())
-      );
-      groups.set(pagePath, {
-        pagePath,
-        pageTitle: result.page || breadcrumbs[breadcrumbs.length - 1] || pagePath,
-        breadcrumbs,
-        results: [],
-      });
+      const pageTitle = r.page || pagePath.split('/').pop().replace(/[-_]/g, ' ');
+      groups.set(pagePath, { pagePath, pageTitle, breadcrumbs: [pageTitle], results: [] });
     }
-    const r = { ...result, _flatIndex: flatIndex++ };
-    groups.get(pagePath).results.push(r);
-  }
+    groups.get(pagePath).results.push({ ...r });
+  });
   
-  return Array.from(groups.values());
+  const arr = Array.from(groups.values());
+  let i = 0; arr.forEach(g => g.results.forEach(r => r._flatIndex = i++));
+  return arr;
 });
 
 // Calculate counts per category based on current unfiltered results
@@ -274,15 +278,23 @@ watch(filteredResults, () => {
 
 // Toggle a filter
 function toggleFilter(filter) {
-  if (filter === '') {
-    selectedFilter.value = '';
-    return;
-  }
   if (selectedFilter.value === filter) {
     selectedFilter.value = '';
   } else {
     selectedFilter.value = filter;
   }
+  nextTick(() => searchInputRef.value?.focus());
+}
+
+function toggleFiltersVisibility() {
+  showFilters.value = !showFilters.value;
+  nextTick(() => searchInputRef.value?.focus());
+}
+
+function toggleCollected() {
+  isCollected.value = !isCollected.value;
+  selectedIndex.value = -1;
+  nextTick(() => searchInputRef.value?.focus());
 }
 
 // Close modal when clicking a result link

--- a/docs/src/components/DocumenterSearch.vue
+++ b/docs/src/components/DocumenterSearch.vue
@@ -28,6 +28,14 @@
               @input="onInput"
               @keydown.esc="isOpen = false"
             />
+            <button @click="showFilters = !showFilters" class="filter-toggle-btn" title="Toggle Filters" style="margin-right: 8px;">
+              <svg v-if="!showFilters" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"></polygon>
+              </svg>
+              <svg v-else xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <line x1="4" y1="21" x2="4" y2="14"></line><line x1="4" y1="10" x2="4" y2="3"></line><line x1="12" y1="21" x2="12" y2="12"></line><line x1="12" y1="8" x2="12" y2="3"></line><line x1="20" y1="21" x2="20" y2="16"></line><line x1="20" y1="12" x2="20" y2="3"></line><line x1="1" y1="14" x2="7" y2="14"></line><line x1="9" y1="8" x2="15" y2="8"></line><line x1="17" y1="16" x2="23" y2="16"></line>
+              </svg>
+            </button>
             <button class="close-btn" @click="isOpen = false">Esc</button>
           </div>
 
@@ -40,27 +48,26 @@
             
             <div v-else>
               <!-- Filters -->
-              <div class="is-flex gap-2 is-flex-wrap-wrap is-justify-content-flex-start is-align-items-center search-filters">
-                <span class="is-size-6" style="margin-right: 12px; font-weight: bold;">Filters:</span>
-                <button 
-                  class="search-filter"
-                  :class="{ 'search-filter-selected': selectedFilter === '' }"
-                  @click="toggleFilter('')"
-                >
-                  All <span class="filter-badge">{{ unfilteredResults.length }}</span>
-                </button>
-                <button 
-                  v-for="filter in availableFilters" 
-                  :key="filter"
-                  class="search-filter"
-                  :class="{ 'search-filter-selected': selectedFilter === filter.toLowerCase() }"
-                  @click="toggleFilter(filter.toLowerCase())"
-                >
-                  {{ filter }} <span class="filter-badge">{{ categoryCounts[filter.toLowerCase()] || 0 }}</span>
-                </button>
-              </div>
+              <div v-show="showFilters" class="is-flex gap-2 is-flex-wrap-wrap is-justify-content-flex-start is-align-items-center search-filters" style="margin-bottom: 12px;">
+                  <button 
+                    class="search-filter"
+                    :class="{ 'search-filter-selected': selectedFilter === '' }"
+                    @click="toggleFilter('')"
+                  >
+                    All <span class="filter-badge">{{ unfilteredResults.length }}</span>
+                  </button>
+                  <button 
+                    v-for="filter in availableFilters" 
+                    :key="filter"
+                    class="search-filter"
+                    :class="{ 'search-filter-selected': selectedFilter === filter.toLowerCase() }"
+                    @click="toggleFilter(filter.toLowerCase())"
+                  >
+                    {{ filter }} <span class="filter-badge">{{ categoryCounts[filter.toLowerCase()] || 0 }}</span>
+                  </button>
+                </div>
               
-              <div class="search-divider"></div>
+              <div class="search-divider" v-show="showFilters"></div>
               
               <!-- Result Count -->
               <div class="is-size-6 result-count">
@@ -88,6 +95,7 @@
 import { ref, computed, onMounted, onUnmounted, watch, nextTick } from 'vue';
 
 const isOpen = ref(false);
+const showFilters = ref(true);
 const searchQuery = ref('');
 const searchInputRef = ref(null);
 const selectedFilter = ref('');
@@ -206,7 +214,7 @@ function initWorker() {
       clearInterval(checkInterval);
       
       const index = window.documenterSearchIndex;
-      // Extract unique categories
+      // Extract unique categories dynamically to prevent filtering mismatch
       const categories = [...new Set(index.map(x => x.category))];
       availableFilters.value = categories;
       
@@ -492,20 +500,40 @@ function initWorker() {
 .search-filters {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
-  margin-bottom: 12px;
+  gap: 6px;
   align-items: center;
 }
 
-.search-filter {
+.filter-toggle-btn {
+  background: transparent;
+  border: none;
+  color: var(--vp-c-text-2);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px;
+  border-radius: 6px;
+  transition: background 0.2s, color 0.2s;
+}
+
+.filter-toggle-btn:hover {
   background: var(--vp-c-bg-alt);
+  color: var(--vp-c-brand-1);
+}
+
+.search-filter {
+  background: transparent;
   border: 1px solid var(--vp-c-divider);
-  padding: 4px 10px;
-  border-radius: 16px;
-  font-size: 0.85rem;
+  padding: 2px 8px;
+  border-radius: 12px;
+  font-size: 0.75rem;
   cursor: pointer;
   color: var(--vp-c-text-2);
   transition: all 0.2s;
+  display: flex;
+  align-items: center;
+  gap: 4px;
 }
 
 .search-filter:hover {
@@ -523,16 +551,15 @@ function initWorker() {
 }
 
 .filter-badge {
-  background: var(--vp-c-bg);
+  background: var(--vp-c-bg-soft);
   color: var(--vp-c-text-2);
-  padding: 1px 6px;
-  border-radius: 10px;
-  font-size: 0.7rem;
-  margin-left: 4px;
+  padding: 0 4px;
+  border-radius: 8px;
+  font-size: 0.65rem;
 }
 .search-filter-selected .filter-badge {
-  background: var(--vp-c-brand-soft);
-  color: var(--vp-c-brand-1);
+  background: rgba(255, 255, 255, 0.25);
+  color: white;
 }
 
 .search-divider {

--- a/docs/src/components/DocumenterSearch.vue
+++ b/docs/src/components/DocumenterSearch.vue
@@ -72,7 +72,7 @@
                 No result found!
               </div>
 
-              <div v-else class="is-clipped w-100 is-flex is-flex-direction-column gap-2 is-align-items-flex-start has-text-justified mt-1" @click="handleResultClick">
+              <div v-else class="is-clipped w-100 is-flex is-flex-direction-column gap-2 has-text-justified mt-1" @click="handleResultClick">
                 <div v-for="result in filteredResults" :key="result.location" v-html="result.div"></div>
               </div>
             </div>
@@ -96,6 +96,7 @@ const unfilteredResults = ref([]);
 const isWorkerRunning = ref(false);
 let lastSearchText = '';
 let worker = null;
+let checkInterval = null;
 
 // The filtered results computed on the frontend
 const filteredResults = computed(() => {
@@ -158,9 +159,12 @@ function handleResultClick(e) {
 
 // Global hotkey (Cmd+K / Ctrl+K)
 function handleGlobalKeydown(e) {
-  if ((e.ctrlKey || e.metaKey) && e.key === 'k') {
+  if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'k') {
     e.preventDefault();
     isOpen.value = true;
+  }
+  if (e.key === 'Escape' && isOpen.value) {
+    isOpen.value = false;
   }
 }
 
@@ -174,6 +178,9 @@ onUnmounted(() => {
   if (worker) {
     worker.terminate();
   }
+  if (checkInterval) {
+    clearInterval(checkInterval);
+  }
 });
 
 function launchSearch() {
@@ -183,6 +190,7 @@ function launchSearch() {
     worker.postMessage(lastSearchText);
   } else {
     unfilteredResults.value = [];
+    isWorkerRunning.value = false;
   }
 }
 
@@ -193,7 +201,7 @@ function onInput() {
 }
 
 function initWorker() {
-  const checkInterval = setInterval(() => {
+  checkInterval = setInterval(() => {
     if (typeof window.documenterSearchIndex !== 'undefined') {
       clearInterval(checkInterval);
       
@@ -202,45 +210,55 @@ function initWorker() {
       const categories = [...new Set(index.map(x => x.category))];
       availableFilters.value = categories;
       
-      // We safely try to get deploy base URL from __DEPLOY_ABSPATH__ if defined, otherwise empty string
-      let baseURL = '';
-      try {
-        baseURL = __DEPLOY_ABSPATH__ || '';
-      } catch(e) {}
+      const baseURL = typeof __DEPLOY_ABSPATH__ !== 'undefined' && __DEPLOY_ABSPATH__ !== '' 
+        ? __DEPLOY_ABSPATH__ 
+        : import.meta.env.BASE_URL;
       
       const workerFunction = `
-        function worker_function(documenterSearchIndex, documenterBaseURL, filters) {
+        function worker_function() {
           importScripts("https://cdn.jsdelivr.net/npm/minisearch@6.1.0/dist/umd/index.min.js");
-
-          let data = documenterSearchIndex.map((x, key) => {
-            x["id"] = key;
-            return x;
-          });
 
           const stopWords = new Set(["a","able","about","across","after","almost","also","am","among","an","and","are","as","at","be","because","been","but","by","can","cannot","could","dear","did","does","either","ever","every","from","got","had","has","have","he","her","hers","him","his","how","however","i","if","into","it","its","just","least","like","likely","may","me","might","most","must","my","neither","no","nor","not","of","off","often","on","or","other","our","own","rather","said","say","says","she","should","since","so","some","than","that","the","their","them","then","there","these","they","this","tis","to","too","twas","us","wants","was","we","were","what","when","who","whom","why","will","would","yet","you","your"]);
 
           const juliaTermPattern = /@(?:[\\p{L}_][\\p{L}\\p{M}\\p{N}_]*[!?]?)?|[\\p{L}_][\\p{L}\\p{M}\\p{N}_]*[!?]?|\\p{N}+(?:\\.\\p{N}+)?|(?<![\\p{L}\\p{M}\\p{N}_])(?:[+\\-*\\/\\\\^%<>=!&|~?:.]+|\\p{Sm}+)(?![\\p{L}\\p{M}\\p{N}_])/gu;
 
-          let index = new MiniSearch({
-            fields: ["title", "text"],
-            storeFields: ["location", "title", "text", "category", "page"],
-            processTerm: (term) => {
-              if (typeof term !== "string") return null;
-              const normalized = term.toLowerCase();
-              return stopWords.has(normalized) ? null : normalized;
-            },
-            tokenize: (string) => {
-              if (typeof string !== "string") return [];
-              return string.match(juliaTermPattern) ?? [];
-            },
-            searchOptions: { 
-              prefix: true, 
-              boost: { title: 100 }, 
-              fuzzy: (term) => (term.length >= 5 ? 0.2 : false) 
-            },
-          });
+          let index = null;
+          let documenterBaseURL = '';
+          let filters = [];
 
-          index.addAll(data);
+          self.onmessage = function (e) {
+            if (e.data.type === 'init') {
+              let data = e.data.documenterSearchIndex.map((x, key) => {
+                x["id"] = key;
+                return x;
+              });
+              documenterBaseURL = e.data.documenterBaseURL;
+              filters = e.data.filters;
+
+              index = new MiniSearch({
+                fields: ["title", "text"],
+                storeFields: ["location", "title", "text", "category", "page"],
+                processTerm: (term) => {
+                  if (typeof term !== "string") return null;
+                  const normalized = term.toLowerCase();
+                  return stopWords.has(normalized) ? null : normalized;
+                },
+                tokenize: (string) => {
+                  if (typeof string !== "string") return [];
+                  return string.match(juliaTermPattern) ?? [];
+                },
+                searchOptions: { 
+                  prefix: true, 
+                  boost: { title: 100 }, 
+                  fuzzy: (term) => (term.length >= 5 ? 0.2 : false) 
+                },
+              });
+
+              index.addAll(data);
+              return;
+            }
+
+            if (!index) return;
 
           const htmlEscapes = { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" };
           const reUnescapedHtml = /[&<>"']/g;
@@ -296,7 +314,6 @@ function initWorker() {
             \`;
           }
 
-          self.onmessage = function (e) {
             let query = e.data;
             let results = index.search(query, {
               combineWith: "AND",
@@ -328,10 +345,17 @@ function initWorker() {
         }
       `;
       
-      const workerStr = `(${workerFunction})(${JSON.stringify(index)}, ${JSON.stringify(baseURL)}, ${JSON.stringify(categories)})`;
+      const workerStr = `(${workerFunction})()`;
       const workerBlob = new Blob([workerStr], { type: "text/javascript" });
       worker = new Worker(URL.createObjectURL(workerBlob));
       
+      worker.postMessage({
+        type: 'init',
+        documenterSearchIndex: index,
+        documenterBaseURL: baseURL,
+        filters: categories
+      });
+
       worker.onmessage = (e) => {
         if (lastSearchText !== searchQuery.value) {
           launchSearch();
@@ -583,4 +607,21 @@ function initWorker() {
   color: var(--vp-c-text-3);
   margin-top: 4px;
 }
+
+/* Bulma compatibility utilities for VitePress */
+.has-text-centered { text-align: center; }
+.my-5 { margin-top: 1.5rem; margin-bottom: 1.5rem; }
+.py-5 { padding-top: 1.5rem; padding-bottom: 1.5rem; }
+.is-flex { display: flex; }
+.gap-2 { gap: 0.5rem; }
+.is-flex-wrap-wrap { flex-wrap: wrap; }
+.is-justify-content-flex-start { justify-content: flex-start; }
+.is-align-items-center { align-items: center; }
+.is-size-6 { font-size: 1rem; }
+.is-clipped { overflow: hidden; }
+.w-100 { width: 100%; }
+.is-flex-direction-column { flex-direction: column; }
+.is-align-items-flex-start { align-items: flex-start; }
+.has-text-justified { text-align: justify; }
+.mt-1 { margin-top: 0.25rem; }
 </style>

--- a/docs/src/components/DocumenterSearch.vue
+++ b/docs/src/components/DocumenterSearch.vue
@@ -537,21 +537,22 @@ function initWorker() {
 }
 
 .search-filter:hover {
-  border-color: var(--vp-c-brand-1);
+  border-color: var(--vp-button-brand-border, var(--vp-c-brand-1));
   color: var(--vp-c-brand-1);
 }
 
 .search-filter-selected {
-  background: var(--vp-c-brand-1);
-  color: white;
-  border-color: var(--vp-c-brand-1);
+  background: var(--vp-button-brand-bg, var(--vp-c-brand-1));
+  color: var(--vp-button-brand-text, white);
+  border-color: var(--vp-button-brand-border, var(--vp-c-brand-1));
 }
 .search-filter-selected:hover {
-  color: white;
+  background: var(--vp-button-brand-hover-bg, var(--vp-c-brand-1));
+  color: var(--vp-button-brand-text, white);
 }
 
 .filter-badge {
-  background: var(--vp-c-bg-soft);
+  background: var(--vp-c-bg-soft, var(--vp-c-default-soft));
   color: var(--vp-c-text-2);
   padding: 0 4px;
   border-radius: 8px;
@@ -559,7 +560,7 @@ function initWorker() {
 }
 .search-filter-selected .filter-badge {
   background: rgba(255, 255, 255, 0.25);
-  color: white;
+  color: var(--vp-button-brand-text, white);
 }
 
 .search-divider {
@@ -623,8 +624,8 @@ function initWorker() {
 }
 
 :deep(.search-result-highlight) {
-  background: rgba(255, 200, 0, 0.3);
-  color: inherit;
+  background: var(--vp-c-yellow-soft, rgba(255, 200, 0, 0.3));
+  color: var(--vp-c-yellow-1, inherit);
   font-weight: bold;
 }
 

--- a/docs/src/components/DocumenterSearch.vue
+++ b/docs/src/components/DocumenterSearch.vue
@@ -254,7 +254,7 @@ function initWorker() {
             let search_divider = '<div class="search-divider w-100"></div>';
             let display_link = result.location.slice(0, 50) + (result.location.length > 50 ? "..." : "");
             if (result.page) {
-              display_link += ` (${result.page})`;
+              display_link += " (" + result.page + ")";
             }
 
             let searchstring = escapeRegExp(querystring);

--- a/docs/src/components/DocumenterSearch.vue
+++ b/docs/src/components/DocumenterSearch.vue
@@ -1,0 +1,581 @@
+<template>
+  <div class="VPNavBarSearch">
+    <div class="DocSearch-Button" @click="isOpen = true" aria-label="Search">
+      <span class="DocSearch-Button-Container">
+        <svg class="DocSearch-Search-Icon" width="20" height="20" viewBox="0 0 20 20" aria-label="search icon">
+          <path d="M14.386 14.386l4.0877 4.0877-4.0877-4.0877c-2.9418 2.9419-7.7115 2.9419-10.6533 0-2.9419-2.9418-2.9419-7.7115 0-10.6533 2.9418-2.9419 7.7115-2.9419 10.6533 0 2.9419 2.9418 2.9419 7.7115 0 10.6533z" stroke="currentColor" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round"></path>
+        </svg>
+        <span class="DocSearch-Button-Placeholder">Search</span>
+      </span>
+      <span class="DocSearch-Button-Keys">
+        <kbd class="DocSearch-Button-Key">⌘</kbd>
+        <kbd class="DocSearch-Button-Key">K</kbd>
+      </span>
+    </div>
+
+    <!-- Search Modal -->
+    <Teleport to="body">
+      <div v-if="isOpen" class="custom-search-modal" @click.self="isOpen = false">
+        <div class="custom-search-modal-content">
+          <!-- Header (Search Input) -->
+          <div class="custom-search-header">
+            <svg width="20" height="20" viewBox="0 0 20 20"><path d="M14.386 14.386l4.0877 4.0877-4.0877-4.0877c-2.9418 2.9419-7.7115 2.9419-10.6533 0-2.9419-2.9418-2.9419-7.7115 0-10.6533 2.9418-2.9419 7.7115-2.9419 10.6533 0 2.9419 2.9418 2.9419 7.7115 0 10.6533z" stroke="currentColor" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round"></path></svg>
+            <input 
+              ref="searchInputRef"
+              v-model="searchQuery" 
+              class="documenter-search-input" 
+              placeholder="Search docs" 
+              @input="onInput"
+              @keydown.esc="isOpen = false"
+            />
+            <button class="close-btn" @click="isOpen = false">Esc</button>
+          </div>
+
+          <!-- Body (Filters and Results) -->
+          <div class="search-modal-card-body">
+            
+            <div v-if="searchQuery.trim() === ''" class="has-text-centered my-5 py-5">
+              Type something to get started!
+            </div>
+            
+            <div v-else>
+              <!-- Filters -->
+              <div class="is-flex gap-2 is-flex-wrap-wrap is-justify-content-flex-start is-align-items-center search-filters">
+                <span class="is-size-6" style="margin-right: 12px; font-weight: bold;">Filters:</span>
+                <button 
+                  class="search-filter"
+                  :class="{ 'search-filter-selected': selectedFilter === '' }"
+                  @click="toggleFilter('')"
+                >
+                  All <span class="filter-badge">{{ unfilteredResults.length }}</span>
+                </button>
+                <button 
+                  v-for="filter in availableFilters" 
+                  :key="filter"
+                  class="search-filter"
+                  :class="{ 'search-filter-selected': selectedFilter === filter.toLowerCase() }"
+                  @click="toggleFilter(filter.toLowerCase())"
+                >
+                  {{ filter }} <span class="filter-badge">{{ categoryCounts[filter.toLowerCase()] || 0 }}</span>
+                </button>
+              </div>
+              
+              <div class="search-divider"></div>
+              
+              <!-- Result Count -->
+              <div class="is-size-6 result-count">
+                {{ filteredResults.length >= 200 ? '200+ results' : filteredResults.length + ' result(s)' }}
+              </div>
+
+              <!-- Results -->
+              <div v-if="filteredResults.length === 0" class="has-text-centered my-5 py-5">
+                No result found!
+              </div>
+
+              <div v-else class="is-clipped w-100 is-flex is-flex-direction-column gap-2 is-align-items-flex-start has-text-justified mt-1" @click="handleResultClick">
+                <div v-for="result in filteredResults" :key="result.location" v-html="result.div"></div>
+              </div>
+            </div>
+            
+          </div>
+        </div>
+      </div>
+    </Teleport>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted, onUnmounted, watch, nextTick } from 'vue';
+
+const isOpen = ref(false);
+const searchQuery = ref('');
+const searchInputRef = ref(null);
+const selectedFilter = ref('');
+const availableFilters = ref([]);
+const unfilteredResults = ref([]);
+const isWorkerRunning = ref(false);
+let lastSearchText = '';
+let worker = null;
+
+// The filtered results computed on the frontend
+const filteredResults = computed(() => {
+  let results = unfilteredResults.value;
+  if (selectedFilter.value) {
+    results = results.filter(r => r.category.toLowerCase() === selectedFilter.value);
+  }
+  
+  let final_results = [];
+  let links = new Set();
+  
+  for (let i = 0; i < results.length && final_results.length < 200; ++i) {
+    let res = results[i];
+    if (res.location && !links.has(res.location)) {
+      final_results.push(res);
+      links.add(res.location);
+    }
+  }
+  return final_results;
+});
+
+// Calculate counts per category based on current unfiltered results
+const categoryCounts = computed(() => {
+  const counts = {};
+  for (const result of unfilteredResults.value) {
+    const cat = result.category.toLowerCase();
+    counts[cat] = (counts[cat] || 0) + 1;
+  }
+  return counts;
+});
+
+// Watch for modal open to focus input and attach global listener
+watch(isOpen, (newVal) => {
+  if (newVal) {
+    nextTick(() => {
+      searchInputRef.value?.focus();
+    });
+  }
+});
+
+// Toggle a filter
+function toggleFilter(filter) {
+  if (filter === '') {
+    selectedFilter.value = '';
+    return;
+  }
+  if (selectedFilter.value === filter) {
+    selectedFilter.value = '';
+  } else {
+    selectedFilter.value = filter;
+  }
+}
+
+// Close modal when clicking a result link
+function handleResultClick(e) {
+  if (e.target.closest('.search-result-link')) {
+    isOpen.value = false;
+  }
+}
+
+// Global hotkey (Cmd+K / Ctrl+K)
+function handleGlobalKeydown(e) {
+  if ((e.ctrlKey || e.metaKey) && e.key === 'k') {
+    e.preventDefault();
+    isOpen.value = true;
+  }
+}
+
+onMounted(() => {
+  document.addEventListener('keydown', handleGlobalKeydown);
+  initWorker();
+});
+
+onUnmounted(() => {
+  document.removeEventListener('keydown', handleGlobalKeydown);
+  if (worker) {
+    worker.terminate();
+  }
+});
+
+function launchSearch() {
+  if (worker && searchQuery.value.trim() !== '') {
+    isWorkerRunning.value = true;
+    lastSearchText = searchQuery.value;
+    worker.postMessage(lastSearchText);
+  } else {
+    unfilteredResults.value = [];
+  }
+}
+
+function onInput() {
+  if (!isWorkerRunning.value) {
+    launchSearch();
+  }
+}
+
+function initWorker() {
+  const checkInterval = setInterval(() => {
+    if (typeof window.documenterSearchIndex !== 'undefined') {
+      clearInterval(checkInterval);
+      
+      const index = window.documenterSearchIndex;
+      // Extract unique categories
+      const categories = [...new Set(index.map(x => x.category))];
+      availableFilters.value = categories;
+      
+      // We safely try to get deploy base URL from __DEPLOY_ABSPATH__ if defined, otherwise empty string
+      let baseURL = '';
+      try {
+        baseURL = __DEPLOY_ABSPATH__ || '';
+      } catch(e) {}
+      
+      const workerFunction = `
+        function worker_function(documenterSearchIndex, documenterBaseURL, filters) {
+          importScripts("https://cdn.jsdelivr.net/npm/minisearch@6.1.0/dist/umd/index.min.js");
+
+          let data = documenterSearchIndex.map((x, key) => {
+            x["id"] = key;
+            return x;
+          });
+
+          const stopWords = new Set(["a","able","about","across","after","almost","also","am","among","an","and","are","as","at","be","because","been","but","by","can","cannot","could","dear","did","does","either","ever","every","from","got","had","has","have","he","her","hers","him","his","how","however","i","if","into","it","its","just","least","like","likely","may","me","might","most","must","my","neither","no","nor","not","of","off","often","on","or","other","our","own","rather","said","say","says","she","should","since","so","some","than","that","the","their","them","then","there","these","they","this","tis","to","too","twas","us","wants","was","we","were","what","when","who","whom","why","will","would","yet","you","your"]);
+
+          let index = new MiniSearch({
+            fields: ["title", "text"],
+            storeFields: ["location", "title", "text", "category", "page"],
+            processTerm: (term) => {
+              let word = stopWords.has(term) ? null : term;
+              if (word) {
+                word = word.replace(/^[^\\w@!]+/, "").replace(/[^\\w@!]+$/, "");
+                word = word.toLowerCase();
+              }
+              return word ?? null;
+            },
+            tokenize: (string) => string.split(/[\\s\\-\\.]+/),
+            searchOptions: { prefix: true, boost: { title: 100 }, fuzzy: 2 },
+          });
+
+          index.addAll(data);
+
+          const htmlEscapes = { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" };
+          const reUnescapedHtml = /[&<>"']/g;
+          const reHasUnescapedHtml = RegExp(reUnescapedHtml.source);
+
+          function escape(string) {
+            return string && reHasUnescapedHtml.test(string)
+              ? string.replace(reUnescapedHtml, (chr) => htmlEscapes[chr])
+              : string || "";
+          }
+
+          function escapeRegExp(string) {
+            return string.replace(/[.*+?^\${}()|[\\]\\\\]/g, "\\\\$&");
+          }
+
+          function make_search_result(result, querystring) {
+            let search_divider = '<div class="search-divider w-100"></div>';
+            let display_link = result.location.slice(0, 50) + (result.location.length > 50 ? "..." : "");
+            if (result.page) {
+              display_link += ` (${result.page})`;
+            }
+
+            let searchstring = escapeRegExp(querystring);
+            let textindex = new RegExp(searchstring, "i").exec(result.text || "");
+            let text = textindex !== null
+              ? result.text.slice(Math.max(textindex.index - 100, 0), Math.min(textindex.index + querystring.length + 100, (result.text || "").length))
+              : ""; 
+
+            text = text.length ? escape(text) : "";
+            let display_result = text.length
+              ? "..." + text.replace(new RegExp(escape(searchstring), "i"), '<span class="search-result-highlight">$&</span>') + "..."
+              : "";
+
+            let in_code = !["page", "section"].includes(result.category.toLowerCase());
+            let titleClass = in_code ? "search-result-code-title" : "";
+            
+            // Adjust base URL path handling
+            let finalUrl = documenterBaseURL + (documenterBaseURL.endsWith('/') || result.location.startsWith('/') ? '' : '/') + result.location;
+            finalUrl = finalUrl.replace(/\\/\\//g, '/').replace('http:/', 'http://').replace('https:/', 'https://');
+
+            return \`
+              <a href="\${encodeURI(finalUrl)}" class="search-result-link px-4 py-2">
+                <div class="search-result-header">
+                  <div class="search-result-title \${titleClass}">\${escape(result.title)}</div>
+                  <div class="property-search-result-badge">\${result.category}</div>
+                </div>
+                <p class="search-result-body">\${display_result}</p>
+                <div class="search-result-loc" title="\${result.location}">
+                  \${display_link}
+                </div>
+              </a>
+              \${search_divider}
+            \`;
+          }
+
+          self.onmessage = function (e) {
+            let query = e.data;
+            let results = index.search(query, {
+              filter: (result) => result.score >= 1,
+              combineWith: "AND",
+            });
+
+            let filtered_results = [];
+            let counts = {};
+            for (let filter of filters) counts[filter] = 0;
+            let present = {};
+
+            for (let result of results) {
+              let cat = result.category;
+              let cnt = counts[cat] || 0;
+              if (cnt < 200) {
+                let id = cat + "---" + result.location;
+                if (!present[id]) {
+                  present[id] = true;
+                  counts[cat] = cnt + 1;
+                  filtered_results.push({
+                    location: result.location,
+                    category: cat,
+                    div: make_search_result(result, query),
+                  });
+                }
+              }
+            }
+            postMessage(filtered_results);
+          };
+        }
+      `;
+      
+      const workerStr = `(${workerFunction})(${JSON.stringify(index)}, ${JSON.stringify(baseURL)}, ${JSON.stringify(categories)})`;
+      const workerBlob = new Blob([workerStr], { type: "text/javascript" });
+      worker = new Worker(URL.createObjectURL(workerBlob));
+      
+      worker.onmessage = (e) => {
+        if (lastSearchText !== searchQuery.value) {
+          launchSearch();
+        } else {
+          isWorkerRunning.value = false;
+        }
+        unfilteredResults.value = e.data;
+      };
+    }
+  }, 1000);
+}
+</script>
+
+<style scoped>
+/* 
+  VitePress Search Button Styling 
+  Attempts to match VPNavBarSearch default styles
+*/
+.VPNavBarSearch {
+  display: flex;
+  align-items: center;
+}
+.DocSearch-Button {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 0;
+  padding: 0 10px 0 12px;
+  width: 100%;
+  height: 40px;
+  background: var(--vp-c-bg-alt);
+  border-radius: 8px;
+  color: var(--vp-c-text-2);
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: border-color 0.25s, background-color 0.25s;
+}
+.DocSearch-Button:hover {
+  background: transparent;
+  border-color: var(--vp-c-brand-1);
+}
+.DocSearch-Button-Container {
+  display: flex;
+  align-items: center;
+}
+.DocSearch-Search-Icon {
+  width: 16px;
+  height: 16px;
+  margin-right: 8px;
+}
+.DocSearch-Button-Placeholder {
+  font-size: 13px;
+  font-weight: 500;
+}
+.DocSearch-Button-Keys {
+  display: flex;
+  margin-left: 16px;
+  min-width: calc(40px + 0.2em);
+}
+.DocSearch-Button-Key {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 22px;
+  height: 22px;
+  margin-right: 4px;
+  border-radius: 4px;
+  background-color: var(--vp-c-bg);
+  border: 1px solid var(--vp-c-divider);
+  box-shadow: 0 1px 1px rgba(0,0,0,0.1);
+  font-size: 12px;
+  font-family: var(--vp-font-family-base);
+}
+
+/* Modal Styling */
+.custom-search-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: rgba(0, 0, 0, 0.6);
+  z-index: 1000;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding-top: 10vh;
+  backdrop-filter: blur(4px);
+}
+
+.custom-search-modal-content {
+  background: var(--vp-c-bg);
+  width: 90%;
+  max-width: 700px;
+  border-radius: 12px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  max-height: 80vh;
+}
+
+.custom-search-header {
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--vp-c-divider);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.documenter-search-input {
+  flex-grow: 1;
+  background: transparent;
+  border: none;
+  outline: none;
+  font-size: 1.1rem;
+  color: var(--vp-c-text-1);
+}
+
+.close-btn {
+  background: var(--vp-c-bg-alt);
+  border: 1px solid var(--vp-c-divider);
+  padding: 4px 8px;
+  border-radius: 6px;
+  font-size: 0.8rem;
+  color: var(--vp-c-text-2);
+  cursor: pointer;
+}
+
+.search-modal-card-body {
+  padding: 20px;
+  overflow-y: auto;
+}
+
+/* Filters */
+.search-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 12px;
+  align-items: center;
+}
+
+.search-filter {
+  background: var(--vp-c-bg-alt);
+  border: 1px solid var(--vp-c-divider);
+  padding: 4px 10px;
+  border-radius: 16px;
+  font-size: 0.85rem;
+  cursor: pointer;
+  color: var(--vp-c-text-2);
+  transition: all 0.2s;
+}
+
+.search-filter:hover {
+  border-color: var(--vp-c-brand-1);
+  color: var(--vp-c-brand-1);
+}
+
+.search-filter-selected {
+  background: var(--vp-c-brand-1);
+  color: white;
+  border-color: var(--vp-c-brand-1);
+}
+.search-filter-selected:hover {
+  color: white;
+}
+
+.filter-badge {
+  background: var(--vp-c-bg);
+  color: var(--vp-c-text-2);
+  padding: 1px 6px;
+  border-radius: 10px;
+  font-size: 0.7rem;
+  margin-left: 4px;
+}
+.search-filter-selected .filter-badge {
+  background: var(--vp-c-brand-soft);
+  color: var(--vp-c-brand-1);
+}
+
+.search-divider {
+  height: 1px;
+  background: var(--vp-c-divider);
+  margin: 12px 0;
+}
+
+.result-count {
+  margin-bottom: 16px;
+  color: var(--vp-c-text-2);
+}
+
+/* Results */
+:deep(.search-result-link) {
+  display: block;
+  text-decoration: none !important;
+  padding: 12px;
+  border-radius: 8px;
+  transition: background 0.2s;
+  color: inherit;
+}
+:deep(.search-result-link:hover) {
+  background: var(--vp-c-bg-alt);
+}
+
+:deep(.search-result-header) {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 4px;
+}
+
+:deep(.search-result-title) {
+  font-weight: 600;
+  color: var(--vp-c-brand-1);
+}
+
+:deep(.search-result-code-title) {
+  font-family: monospace;
+}
+
+:deep(.property-search-result-badge) {
+  font-size: 0.7rem;
+  background: var(--vp-c-brand-soft);
+  color: var(--vp-c-brand-1);
+  padding: 2px 6px;
+  border-radius: 4px;
+  text-transform: uppercase;
+}
+
+:deep(.search-result-body) {
+  font-size: 0.9rem;
+  color: var(--vp-c-text-2);
+  margin: 4px 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+:deep(.search-result-highlight) {
+  background: rgba(255, 200, 0, 0.3);
+  color: inherit;
+  font-weight: bold;
+}
+
+:deep(.search-result-loc) {
+  font-size: 0.8rem;
+  color: var(--vp-c-text-3);
+  margin-top: 4px;
+}
+</style>

--- a/docs/src/components/DocumenterSearch.vue
+++ b/docs/src/components/DocumenterSearch.vue
@@ -219,19 +219,25 @@ function initWorker() {
 
           const stopWords = new Set(["a","able","about","across","after","almost","also","am","among","an","and","are","as","at","be","because","been","but","by","can","cannot","could","dear","did","does","either","ever","every","from","got","had","has","have","he","her","hers","him","his","how","however","i","if","into","it","its","just","least","like","likely","may","me","might","most","must","my","neither","no","nor","not","of","off","often","on","or","other","our","own","rather","said","say","says","she","should","since","so","some","than","that","the","their","them","then","there","these","they","this","tis","to","too","twas","us","wants","was","we","were","what","when","who","whom","why","will","would","yet","you","your"]);
 
+          const juliaTermPattern = /@(?:[\\p{L}_][\\p{L}\\p{M}\\p{N}_]*[!?]?)?|[\\p{L}_][\\p{L}\\p{M}\\p{N}_]*[!?]?|\\p{N}+(?:\\.\\p{N}+)?|(?<![\\p{L}\\p{M}\\p{N}_])(?:[+\\-*\\/\\\\^%<>=!&|~?:.]+|\\p{Sm}+)(?![\\p{L}\\p{M}\\p{N}_])/gu;
+
           let index = new MiniSearch({
             fields: ["title", "text"],
             storeFields: ["location", "title", "text", "category", "page"],
             processTerm: (term) => {
-              let word = stopWords.has(term) ? null : term;
-              if (word) {
-                word = word.replace(/^[^\\w@!]+/, "").replace(/[^\\w@!]+$/, "");
-                word = word.toLowerCase();
-              }
-              return word ?? null;
+              if (typeof term !== "string") return null;
+              const normalized = term.toLowerCase();
+              return stopWords.has(normalized) ? null : normalized;
             },
-            tokenize: (string) => string.split(/[\\s\\-\\.]+/),
-            searchOptions: { prefix: true, boost: { title: 100 }, fuzzy: 2 },
+            tokenize: (string) => {
+              if (typeof string !== "string") return [];
+              return string.match(juliaTermPattern) ?? [];
+            },
+            searchOptions: { 
+              prefix: true, 
+              boost: { title: 100 }, 
+              fuzzy: (term) => (term.length >= 5 ? 0.2 : false) 
+            },
           });
 
           index.addAll(data);
@@ -293,7 +299,6 @@ function initWorker() {
           self.onmessage = function (e) {
             let query = e.data;
             let results = index.search(query, {
-              filter: (result) => result.score >= 1,
               combineWith: "AND",
             });
 

--- a/docs/src/components/DocumenterSearch.vue
+++ b/docs/src/components/DocumenterSearch.vue
@@ -299,14 +299,14 @@ function initWorker() {
 
             return \`
               <a href="\${finalUrl}" class="search-result-link px-4 py-2">
+                <div class="search-result-loc" title="\${result.location}">
+                  \${display_link}
+                </div>
                 <div class="search-result-header">
                   <div class="search-result-title \${titleClass}">\${escape(result.title)}</div>
                   <div class="property-search-result-badge">\${result.category}</div>
                 </div>
                 <p class="search-result-body">\${display_result}</p>
-                <div class="search-result-loc" title="\${result.location}">
-                  \${display_link}
-                </div>
               </a>
               \${search_divider}
             \`;
@@ -567,6 +567,7 @@ function initWorker() {
 }
 
 :deep(.search-result-title) {
+  font-size: 0.95rem;
   font-weight: 600;
   color: var(--vp-c-brand-1);
 }
@@ -576,7 +577,7 @@ function initWorker() {
 }
 
 :deep(.property-search-result-badge) {
-  font-size: 0.7rem;
+  font-size: 0.65rem;
   background: var(--vp-c-brand-soft);
   color: var(--vp-c-brand-1);
   padding: 2px 6px;
@@ -585,9 +586,9 @@ function initWorker() {
 }
 
 :deep(.search-result-body) {
-  font-size: 0.9rem;
+  font-size: 0.85rem;
   color: var(--vp-c-text-2);
-  margin: 4px 0;
+  margin: 4px 0 0 0;
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
@@ -601,9 +602,10 @@ function initWorker() {
 }
 
 :deep(.search-result-loc) {
-  font-size: 0.8rem;
+  font-size: 0.75rem;
   color: var(--vp-c-text-3);
-  margin-top: 4px;
+  margin-bottom: 4px;
+  font-weight: 500;
 }
 
 /* Bulma compatibility utilities for VitePress */

--- a/docs/src/components/DocumenterSearch.vue
+++ b/docs/src/components/DocumenterSearch.vue
@@ -241,8 +241,10 @@ const groupedResults = computed(() => {
   filteredResults.value.forEach(r => {
     const pagePath = r.location.split('#')[0];
     if (!groups.has(pagePath)) {
-      const pageTitle = r.page || pagePath.split('/').pop().replace(/[-_]/g, ' ');
-      groups.set(pagePath, { pagePath, pageTitle, breadcrumbs: [pageTitle], results: [] });
+      const segments = pagePath.replace(/\.[^.]+$/, '').split('/');
+      const breadcrumbs = segments.map(s => s.replace(/[-_]/g, ' ').replace(/\b\w/g, c => c.toUpperCase()));
+      const pageTitle = r.page || breadcrumbs[breadcrumbs.length - 1] || pagePath;
+      groups.set(pagePath, { pagePath, pageTitle, breadcrumbs, results: [] });
     }
     groups.get(pagePath).results.push({ ...r });
   });

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -275,13 +275,38 @@ function render(doc::Documenter.Document, settings::MarkdownVitepress=MarkdownVi
             )
             push!(inventory, item)
         end
-        push!(search_index, Dict(
-            "title" => _pagetitle(page),
-            "text" => "",
-            "location" => _get_inventory_uri(doc, page, nothing),
-            "category" => "page",
-            "page" => _pagetitle(page)
-        ))
+        current_heading_id = nothing
+        current_heading_text = _pagetitle(page)
+        current_text = String[]
+
+        function flush_section!()
+            text = strip(join(current_text, " "))
+            if !isempty(text)
+                push!(search_index, Dict(
+                    "title" => current_heading_text,
+                    "text" => text,
+                    "location" => _get_inventory_uri(doc, page, current_heading_id),
+                    "category" => current_heading_id === nothing ? "page" : "section",
+                    "page" => _pagetitle(page)
+                ))
+            end
+            empty!(current_text)
+        end
+
+        for node in page.mdast.children
+            if node.element isa Documenter.AnchoredHeader
+                flush_section!()
+                anchor = node.element.anchor
+                current_heading_id = replace(sanitized_anchor_label(anchor), " " => "-")
+                current_heading_text = Documenter.MDFlatten.mdflatten(first(node.children))
+            elseif node.element isa Documenter.DocsNode
+                # Docstrings are handled by render; we skip their text here
+                continue
+            else
+                push!(current_text, Documenter.MDFlatten.mdflatten(node))
+            end
+        end
+        flush_section!()
     end
     
     # Write the search index to a JS file so the frontend can load it
@@ -1250,15 +1275,6 @@ function render(io::IO, mime::MIME"text/plain", node::Documenter.MarkdownAST.Nod
             uri = _get_inventory_uri(doc, page, id),
         )
         push!(kwargs[:inventory], item)
-    end
-    if haskey(kwargs, :search_index)
-        push!(kwargs[:search_index], Dict(
-            "title" => heading_text,
-            "text" => "",
-            "location" => _get_inventory_uri(doc, page, id),
-            "category" => "section",
-            "page" => _pagetitle(page)
-        ))
     end
     println(io)
 end

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -248,7 +248,7 @@ function render(doc::Documenter.Document, settings::MarkdownVitepress=MarkdownVi
         nothing
     end
 
-    search_index = []
+    search_index = Dict{String, Any}[]
 
     # Iterate over the pages, render each page separately
     for (src, page) in doc.blueprint.pages
@@ -293,7 +293,24 @@ function render(doc::Documenter.Document, settings::MarkdownVitepress=MarkdownVi
             empty!(current_text)
         end
 
+        in_frontmatter = false
+        is_first_node = true
         for node in page.mdast.children
+            if is_first_node && node.element isa MarkdownAST.ThematicBreak
+                in_frontmatter = true
+                is_first_node = false
+                continue
+            end
+            if in_frontmatter && node.element isa MarkdownAST.ThematicBreak
+                in_frontmatter = false
+                continue
+            end
+            is_first_node = false
+            
+            if in_frontmatter || (node.element isa MarkdownAST.CodeBlock && node.element.info == "@frontmatter") || (node.element isa Documenter.RawNode && startswith(node.element.text, "---"))
+                continue
+            end
+
             if node.element isa Documenter.AnchoredHeader
                 flush_section!()
                 anchor = node.element.anchor

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -248,6 +248,8 @@ function render(doc::Documenter.Document, settings::MarkdownVitepress=MarkdownVi
         nothing
     end
 
+    search_index = []
+
     # Iterate over the pages, render each page separately
     for (src, page) in doc.blueprint.pages
         # This is where you can operate on a per-page level.
@@ -255,9 +257,9 @@ function render(doc::Documenter.Document, settings::MarkdownVitepress=MarkdownVi
             merge_and_render_frontmatter(io, MIME("text/yaml"), page, doc)
             for node in page.mdast.children
                 kwargs = if settings.write_inventory
-                    (; inventory = inventory)
+                    (; inventory = inventory, search_index = search_index)
                 else
-                    (;)
+                    (; search_index = search_index)
                 end
                 render(io, mime, node, page, doc; kwargs...)
             end
@@ -273,6 +275,20 @@ function render(doc::Documenter.Document, settings::MarkdownVitepress=MarkdownVi
             )
             push!(inventory, item)
         end
+        push!(search_index, Dict(
+            "title" => _pagetitle(page),
+            "text" => "",
+            "location" => _get_inventory_uri(doc, page, nothing),
+            "category" => "page",
+            "page" => _pagetitle(page)
+        ))
+    end
+    
+    # Write the search index to a JS file so the frontend can load it
+    open(joinpath(builddir, settings.md_output_path, "public", "documenter_search_index.js"), "w") do io
+        print(io, "window.documenterSearchIndex = ")
+        JSON.print(io, search_index)
+        println(io)
     end
     if settings.write_inventory
         objects_inv = joinpath(builddir, settings.md_output_path, "public", "objects.inv")
@@ -628,6 +644,16 @@ function render(io::IO, mime::MIME"text/plain", node::Documenter.MarkdownAST.Nod
             uri = _get_inventory_uri(doc, page, anchor_id),
         )
         push!(kwargs[:inventory], item)
+    end
+    if haskey(kwargs, :search_index)
+        text = Documenter.MDFlatten.mdflatten(node)
+        push!(kwargs[:search_index], Dict(
+            "title" => string(docs.object.binding),
+            "text" => text,
+            "location" => _get_inventory_uri(doc, page, anchor_id),
+            "category" => category,
+            "page" => _pagetitle(page)
+        ))
     end
     # Docstring header based on the name of the binding and it's category.
     _badge_text = """<Badge type="info" class="jlObjectType jl$(category)" text="$(category)" />"""
@@ -1224,6 +1250,15 @@ function render(io::IO, mime::MIME"text/plain", node::Documenter.MarkdownAST.Nod
             uri = _get_inventory_uri(doc, page, id),
         )
         push!(kwargs[:inventory], item)
+    end
+    if haskey(kwargs, :search_index)
+        push!(kwargs[:search_index], Dict(
+            "title" => heading_text,
+            "text" => "",
+            "location" => _get_inventory_uri(doc, page, id),
+            "category" => "section",
+            "page" => _pagetitle(page)
+        ))
     end
     println(io)
 end


### PR DESCRIPTION
I asked gemini to do a port of Documenter.jl s [search.js](https://github.com/JuliaDocs/Documenter.jl/blob/c955fe8112b5503ae363cc7d0e315eff10c37d63/assets/html/js/search.js) approach into a new Vue component. And it actually works quite well. 

I will need to go over the code and do some cleanup, but it looks promising. I don't think it will be the default but people could opt-in if they want to. 

Maybe it closes #190 

<img width="700" height="560" alt="Screenshot 2026-07-16 at 19 51 21" src="https://github.com/user-attachments/assets/f9aa96e1-12b6-444c-af1e-8854d1da40ed" />


<img width="712" height="584" alt="Screenshot 2026-07-16 at 17 06 55" src="https://github.com/user-attachments/assets/546fdcd1-2b9a-427d-b121-e8d65608d017" />
<img width="731" height="603" alt="Screenshot 2026-07-16 at 17 06 44" src="https://github.com/user-attachments/assets/cdfbe7ae-a8ba-40ab-8d6c-a17c0e5c45c2" />

