### PR TITLE
Improve local search for Julia documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+- Improved VitePress local search with Julia-aware Unicode tokenization, case-insensitive stop-word handling, stricter multi-term matching, heading-focused ranking, and length-gated fuzzy matching [#190](https://github.com/LuxDL/DocumenterVitepress.jl/issues/190)
+
 ## v0.3.5 - 2026-07-14
 
 - Cleaned up `docs/make.jl` by removing unused `DocumenterCitations` integration code and clarifying remaining dependencies [#382](https://github.com/LuxDL/DocumenterVitepress.jl/pull/382).

--- a/docs/src/.vitepress/config.mts
+++ b/docs/src/.vitepress/config.mts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vitepress'
 import { tabsMarkdownPlugin } from 'vitepress-plugin-tabs'
 import { mathjaxPlugin } from './mathjax-plugin'
 import { juliaReplTransformer } from './julia-repl-transformer'
+import { documenterVitepressSearchOptions } from './search-options.mjs'
 import footnote from "markdown-it-footnote";
 import path from 'path'
 
@@ -92,7 +93,8 @@ export default defineConfig({
     search: {
       provider: 'local',
       options: {
-        detailedView: true
+        detailedView: true,
+        miniSearch: documenterVitepressSearchOptions
       }
     },
     nav,

--- a/docs/src/.vitepress/search-options.mjs
+++ b/docs/src/.vitepress/search-options.mjs
@@ -1,0 +1,147 @@
+// MiniSearch defaults tuned for Julia documentation.
+
+// Based on Documenter's long-standing stop-word list, with names from Base
+// (all, any, get, in, is, only, which) and Julia keywords
+// (do, else, for, let, where, while, with) intentionally retained.
+const stopWords = new Set([
+  'a',
+  'able',
+  'about',
+  'across',
+  'after',
+  'almost',
+  'also',
+  'am',
+  'among',
+  'an',
+  'and',
+  'are',
+  'as',
+  'at',
+  'be',
+  'because',
+  'been',
+  'but',
+  'by',
+  'can',
+  'cannot',
+  'could',
+  'dear',
+  'did',
+  'does',
+  'either',
+  'ever',
+  'every',
+  'from',
+  'got',
+  'had',
+  'has',
+  'have',
+  'he',
+  'her',
+  'hers',
+  'him',
+  'his',
+  'how',
+  'however',
+  'i',
+  'if',
+  'into',
+  'it',
+  'its',
+  'just',
+  'least',
+  'like',
+  'likely',
+  'may',
+  'me',
+  'might',
+  'most',
+  'must',
+  'my',
+  'neither',
+  'no',
+  'nor',
+  'not',
+  'of',
+  'off',
+  'often',
+  'on',
+  'or',
+  'other',
+  'our',
+  'own',
+  'rather',
+  'said',
+  'say',
+  'says',
+  'she',
+  'should',
+  'since',
+  'so',
+  'some',
+  'than',
+  'that',
+  'the',
+  'their',
+  'them',
+  'then',
+  'there',
+  'these',
+  'they',
+  'this',
+  'tis',
+  'to',
+  'too',
+  'twas',
+  'us',
+  'wants',
+  'was',
+  'we',
+  'were',
+  'what',
+  'when',
+  'who',
+  'whom',
+  'why',
+  'will',
+  'would',
+  'yet',
+  'you',
+  'your'
+])
+
+// Match Julia identifiers and macros, numbers, and standalone operators.
+// Punctuation between identifiers remains a separator, so qualified names and
+// signatures become useful component terms without losing `@`, `!`, `?`, or
+// operator searches. The lookarounds keep prose such as `full-text` from
+// producing a noisy standalone `-` term.
+const juliaTermPattern =
+  /@[\p{L}_][\p{L}\p{M}\p{N}_]*[!?]?|[\p{L}_][\p{L}\p{M}\p{N}_]*[!?]?|\p{N}+(?:\.\p{N}+)?|(?<![\p{L}\p{M}\p{N}_])(?:[+\-*\/\\^%<>=!&|~?:.]+|\p{Sm}+)(?![\p{L}\p{M}\p{N}_])/gu
+
+function tokenizeJuliaTerms(text) {
+  return text.match(juliaTermPattern) ?? []
+}
+
+function processJuliaTerm(term) {
+  const normalized = term.toLowerCase()
+  return stopWords.has(normalized) ? null : normalized
+}
+
+/**
+ * Julia-aware defaults for VitePress local search.
+ *
+ * @type {NonNullable<import('vitepress').DefaultTheme.LocalSearchOptions['miniSearch']>}
+ */
+export const documenterVitepressSearchOptions = {
+  options: {
+    tokenize: tokenizeJuliaTerms,
+    processTerm: processJuliaTerm
+  },
+  searchOptions: {
+    combineWith: 'AND',
+    prefix: true,
+    fuzzy: (term) => (term.length >= 5 ? 0.2 : false),
+    boost: { title: 10, titles: 2, text: 1 }
+  }
+}

--- a/docs/src/manual/get_started.md
+++ b/docs/src/manual/get_started.md
@@ -277,7 +277,8 @@ This creates the following structure in your `docs/src` folder:
 ```
 docs/src/
 ├── .vitepress/
-│   ├── config.mts      # Main Vitepress configuration
+│   ├── config.mts         # Main Vitepress configuration
+│   ├── search-options.mjs # Julia-aware local search defaults
 │   └── theme/
 │       ├── index.ts    # Theme customization
 │       └── style.css   # Custom styles
@@ -290,6 +291,7 @@ docs/src/
 ### What Gets Generated
 
 - **`config.mts`**: The main Vitepress configuration file. Edit this to customize navigation, sidebar, search, and other site settings.
+- **`search-options.mjs`**: Julia-aware MiniSearch tokenization and ranking defaults used by the generated configuration.
 - **`theme/index.ts`**: Theme entry point. Use this to add custom Vue components or override Vitepress theme defaults.
 - **`theme/style.css`**: Custom CSS styles for your documentation.
 - **`assets/`**: Images and icons used by your documentation.
@@ -307,6 +309,29 @@ Once you've generated the template:
 4. Build as usual with `include("make.jl")`
 
 For detailed Vitepress configuration options, see the [Vitepress documentation](https://vitepress.dev/reference/site-config).
+
+### Using the Julia-aware Search Defaults in an Existing Configuration
+
+DocumenterVitepress does not rewrite a custom `config.mts`. To opt an existing configuration into the default Julia-aware local search, import the search options module and pass it to Vitepress:
+
+```ts [config.mts]
+import { defineConfig } from 'vitepress'
+import { documenterVitepressSearchOptions } from './search-options.mjs'
+
+export default defineConfig({
+  themeConfig: {
+    search: {
+      provider: 'local',
+      options: {
+        detailedView: true,
+        miniSearch: documenterVitepressSearchOptions
+      }
+    }
+  }
+})
+```
+
+The `search-options.mjs` fallback is copied into the generated Vitepress build automatically. It can also be created in the source tree with `DocumenterVitepress.generate_template` if you want to customize its tokenization or ranking.
 
 ## Common Issues and Solutions
 

--- a/src/vitepress_config.jl
+++ b/src/vitepress_config.jl
@@ -38,7 +38,7 @@ function modify_config_file(doc, settings, deploy_decision, i_folder, base)
     mkpath(joinpath(build_vitepress_dir, "theme"))
 
     # Check for the config and plugin files
-    for f in ["config.mts", "mathjax-plugin.ts", "julia-repl-transformer.ts"]
+    for f in ["config.mts", "mathjax-plugin.ts", "julia-repl-transformer.ts", "search-options.mjs"]
         vitepress_config_file = joinpath(source_vitepress_dir, f) # We check the source dir here because `clean=false` will persist the old, non-generated file in the build dir, and we need to overwrite it.
         if !isfile(vitepress_config_file)
             mkpath(splitdir(vitepress_config_file)[1])

--- a/template/src/.vitepress/config.mts
+++ b/template/src/.vitepress/config.mts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vitepress'
 import { tabsMarkdownPlugin } from 'vitepress-plugin-tabs'
 import { mathjaxPlugin } from './mathjax-plugin'
 import { juliaReplTransformer } from './julia-repl-transformer'
+import { documenterVitepressSearchOptions } from './search-options.mjs'
 import footnote from "markdown-it-footnote";
 import path from 'path'
 
@@ -89,7 +90,8 @@ export default defineConfig({
     search: {
       provider: 'local',
       options: {
-        detailedView: true
+        detailedView: true,
+        miniSearch: documenterVitepressSearchOptions
       }
     },
     nav,

--- a/template/src/.vitepress/search-options.mjs
+++ b/template/src/.vitepress/search-options.mjs
@@ -1,0 +1,147 @@
+// MiniSearch defaults tuned for Julia documentation.
+
+// Based on Documenter's long-standing stop-word list, with names from Base
+// (all, any, get, in, is, only, which) and Julia keywords
+// (do, else, for, let, where, while, with) intentionally retained.
+const stopWords = new Set([
+  'a',
+  'able',
+  'about',
+  'across',
+  'after',
+  'almost',
+  'also',
+  'am',
+  'among',
+  'an',
+  'and',
+  'are',
+  'as',
+  'at',
+  'be',
+  'because',
+  'been',
+  'but',
+  'by',
+  'can',
+  'cannot',
+  'could',
+  'dear',
+  'did',
+  'does',
+  'either',
+  'ever',
+  'every',
+  'from',
+  'got',
+  'had',
+  'has',
+  'have',
+  'he',
+  'her',
+  'hers',
+  'him',
+  'his',
+  'how',
+  'however',
+  'i',
+  'if',
+  'into',
+  'it',
+  'its',
+  'just',
+  'least',
+  'like',
+  'likely',
+  'may',
+  'me',
+  'might',
+  'most',
+  'must',
+  'my',
+  'neither',
+  'no',
+  'nor',
+  'not',
+  'of',
+  'off',
+  'often',
+  'on',
+  'or',
+  'other',
+  'our',
+  'own',
+  'rather',
+  'said',
+  'say',
+  'says',
+  'she',
+  'should',
+  'since',
+  'so',
+  'some',
+  'than',
+  'that',
+  'the',
+  'their',
+  'them',
+  'then',
+  'there',
+  'these',
+  'they',
+  'this',
+  'tis',
+  'to',
+  'too',
+  'twas',
+  'us',
+  'wants',
+  'was',
+  'we',
+  'were',
+  'what',
+  'when',
+  'who',
+  'whom',
+  'why',
+  'will',
+  'would',
+  'yet',
+  'you',
+  'your'
+])
+
+// Match Julia identifiers and macros, numbers, and standalone operators.
+// Punctuation between identifiers remains a separator, so qualified names and
+// signatures become useful component terms without losing `@`, `!`, `?`, or
+// operator searches. The lookarounds keep prose such as `full-text` from
+// producing a noisy standalone `-` term.
+const juliaTermPattern =
+  /@[\p{L}_][\p{L}\p{M}\p{N}_]*[!?]?|[\p{L}_][\p{L}\p{M}\p{N}_]*[!?]?|\p{N}+(?:\.\p{N}+)?|(?<![\p{L}\p{M}\p{N}_])(?:[+\-*\/\\^%<>=!&|~?:.]+|\p{Sm}+)(?![\p{L}\p{M}\p{N}_])/gu
+
+function tokenizeJuliaTerms(text) {
+  return text.match(juliaTermPattern) ?? []
+}
+
+function processJuliaTerm(term) {
+  const normalized = term.toLowerCase()
+  return stopWords.has(normalized) ? null : normalized
+}
+
+/**
+ * Julia-aware defaults for VitePress local search.
+ *
+ * @type {NonNullable<import('vitepress').DefaultTheme.LocalSearchOptions['miniSearch']>}
+ */
+export const documenterVitepressSearchOptions = {
+  options: {
+    tokenize: tokenizeJuliaTerms,
+    processTerm: processJuliaTerm
+  },
+  searchOptions: {
+    combineWith: 'AND',
+    prefix: true,
+    fuzzy: (term) => (term.length >= 5 ? 0.2 : false),
+    boost: { title: 10, titles: 2, text: 1 }
+  }
+}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -203,6 +203,18 @@ end
         @test occursin("# PDF & SVG", rendered_md)
         @test occursin("&lt;cond&gt;", rendered_md)
 
+        generated_vitepress_dir = joinpath(dir, "build", ".documenter", ".vitepress")
+        generated_search_options = joinpath(generated_vitepress_dir, "search-options.mjs")
+        @test isfile(generated_search_options)
+        generated_config = read(joinpath(generated_vitepress_dir, "config.mts"), String)
+        @test occursin("import { documenterVitepressSearchOptions } from './search-options.mjs'", generated_config)
+        @test occursin("miniSearch: documenterVitepressSearchOptions", generated_config)
+
+        mini_search_module = joinpath(dir, "node_modules", "minisearch", "dist", "es", "index.js")
+        @test isfile(mini_search_module)
+        search_test = joinpath(@__DIR__, "search-options.test.mjs")
+        run(`$(DocumenterVitepress.node()) $search_test $generated_search_options $mini_search_module`)
+
         # The browser-tab title comes from two places, and the bug only manifests in one:
         #   1. The static `<title>` in the HTML head — vitepress HTML-escapes the title
         #      text here, so a bare `&` becomes `&amp;` and renders correctly as `&`.

--- a/test/search-options.test.mjs
+++ b/test/search-options.test.mjs
@@ -1,0 +1,106 @@
+import assert from 'node:assert/strict'
+import { pathToFileURL } from 'node:url'
+
+const [searchOptionsPath, miniSearchPath] = process.argv.slice(2)
+assert.ok(searchOptionsPath, 'expected the generated search-options.mjs path')
+assert.ok(miniSearchPath, 'expected the installed MiniSearch module path')
+
+const { documenterVitepressSearchOptions } = await import(
+  pathToFileURL(searchOptionsPath).href
+)
+const { default: MiniSearch } = await import(pathToFileURL(miniSearchPath).href)
+
+const { tokenize, processTerm } = documenterVitepressSearchOptions.options
+const searchOptions = documenterVitepressSearchOptions.searchOptions
+
+assert.deepEqual(tokenize('Documenter.Anchors.add!'), [
+  'Documenter',
+  'Anchors',
+  'add!'
+])
+assert.deepEqual(tokenize('Base.:+'), ['Base', ':+'])
+assert.deepEqual(tokenize('Array{T,N}'), ['Array', 'T', 'N'])
+assert.deepEqual(tokenize('f(x::Int)'), ['f', 'x', 'Int'])
+assert.deepEqual(tokenize('full-text'), ['full', 'text'])
+assert.deepEqual(tokenize('@time isready?'), ['@time', 'isready?'])
+assert.deepEqual(tokenize('σₓ ⊗ ∂'), ['σₓ', '⊗', '∂'])
+
+assert.equal(processTerm('The'), null)
+assert.equal(processTerm('HOW'), null)
+assert.equal(processTerm('ADD!'), 'add!')
+assert.equal(processTerm('get'), 'get')
+assert.equal(processTerm('in'), 'in')
+assert.equal(processTerm('while'), 'while')
+
+assert.equal(searchOptions.combineWith, 'AND')
+assert.equal(searchOptions.prefix, true)
+assert.equal(searchOptions.fuzzy('four'), false)
+assert.equal(searchOptions.fuzzy('fives'), 0.2)
+assert.deepEqual(searchOptions.boost, { title: 10, titles: 2, text: 1 })
+
+const search = new MiniSearch({
+  fields: ['title', 'titles', 'text'],
+  storeFields: ['title', 'titles', 'text'],
+  ...documenterVitepressSearchOptions.options,
+  searchOptions
+})
+
+search.addAll([
+  {
+    id: 'exact-title',
+    title: 'Documenter.Anchors.add!',
+    titles: ['API Reference'],
+    text: 'Register an anchor in the document.'
+  },
+  {
+    id: 'ancestor-title',
+    title: 'Examples',
+    titles: ['Documenter.Anchors.add!'],
+    text: 'Reference examples.'
+  },
+  {
+    id: 'body-mention',
+    title: 'Navigation guide',
+    titles: ['Guide'],
+    text: 'This page mentions the add! function in prose.'
+  },
+  {
+    id: 'both-terms',
+    title: 'Building the search index',
+    titles: ['Search'],
+    text: 'Configure local results.'
+  },
+  {
+    id: 'search-only',
+    title: 'Search configuration',
+    titles: ['Guide'],
+    text: 'Configure local results.'
+  },
+  {
+    id: 'index-only',
+    title: 'Index construction',
+    titles: ['Guide'],
+    text: 'Build an index efficiently.'
+  },
+  {
+    id: 'short-fuzzy-decoy',
+    title: 'az',
+    titles: ['API Reference'],
+    text: 'A short identifier.'
+  }
+])
+
+const ids = (query) => search.search(query).map(({ id }) => id)
+
+assert.deepEqual(ids('add!').slice(0, 3), [
+  'exact-title',
+  'ancestor-title',
+  'body-mention'
+])
+assert.deepEqual(ids('how to add!'), ids('add!'))
+assert.deepEqual(ids('search index'), ['both-terms'])
+assert.ok(ids('Docu').includes('exact-title'))
+assert.ok(ids('Documemter').includes('exact-title'))
+assert.deepEqual(ids('zz'), [])
+
+console.log('DocumenterVitepress search options tests passed')


### PR DESCRIPTION
## Summary

Closes #190.

This improves the existing VitePress local search for Julia documentation:

- adds a reusable `documenterVitepressSearchOptions` helper to the shipped template and repository docs;
- tokenizes Unicode identifiers, macros, mutating/predicate names, Julia operators, qualified names, parametric types, and method signatures into useful search terms;
- applies case-insensitive technical-documentation stop words while retaining meaningful Julia/Base keywords;
- uses precise defaults: AND matching, prefix completion, length-gated fuzzy matching, and title/ancestor/body boosts;
- documents how existing custom VitePress configurations can opt in; and
- adds real MiniSearch behavior tests plus full VitePress round-trip coverage.

## Why

VitePress already exposes supported MiniSearch hooks, but its general-purpose defaults do not treat Julia syntax as users expect. In particular, qualified names, operators, macros, Unicode names, and identifiers ending in `!` or `?` need language-aware tokenization, while short fuzzy matches create noisy results.

This keeps VitePress's maintained search index and UI and improves relevance at the configuration boundary.

## Difference from #384

#384 explores a larger Documenter-style replacement: it generates a second search index and adds a custom Vue search modal with category filters. This PR takes a smaller, native-VitePress route.

| Area | This PR | #384 |
| --- | --- | --- |
| Search UI/index | Keeps VitePress's built-in local-search UI and index | Adds a custom Vue modal, worker, and writer-generated index |
| Content coverage | Uses VitePress's indexed page/section content, including narrative prose | Its current generated page/section records have empty text; flattened content is attached primarily to docstring records |
| MiniSearch | Uses the MiniSearch 7.x integration bundled with VitePress 1.6.4 | Loads MiniSearch 6.1.0 separately at runtime |
| Julia matching | Unicode-aware tokenization, preserved macros/operators/`!`/`?`, qualified/signature components, and fuzzy matching only for terms of at least five characters | Uses a more general ASCII-oriented tokenizer and an absolute fuzzy distance |
| Rollout | Shipped in new/default templates; existing custom configs can opt in without being overwritten | Adds the custom component to repository docs while the writer emits the extra index |
| UI features | Retains the standard VitePress experience | Adds useful category filters and a larger custom result view |
| Tests | Exercises tokenization and ranking against real MiniSearch and compiles the full generated VitePress site | Primarily covers the Julia-side index writer |

The category-filter concept in #384 could still be explored separately. This PR focuses on improving default search quality with less custom frontend code and no parallel index pipeline.

## Compatibility

- No Julia API or `MarkdownVitepress` keyword changes.
- No npm dependency changes.
- Existing user-provided `config.mts` files are not rewritten.
- Compatible with VitePress 1.6.4 and its MiniSearch 7.x integration.

## Validation

- `julia --project=. --startup-file=no -e 'using Pkg; Pkg.test()'`
- `julia --project=docs --startup-file=no -e 'using Pkg; Pkg.instantiate(); include("docs/make.jl")'`
- `git diff --check`

## AI assistance

This pull request was made with Codex using the **5.6 Sol** model.
