### PR TITLE
fix: correct list numbering and indentation

### DIFF
--- a/src/writer.jl
+++ b/src/writer.jl
@@ -1274,14 +1274,14 @@ function render(io::IO, mime::MIME"text/plain", node::Documenter.MarkdownAST.Nod
 end
 # Lists
 function render(io::IO, mime::MIME"text/plain", node::Documenter.MarkdownAST.Node, list::MarkdownAST.List, page, doc; kwargs...)
-    bullet(i) = list.type === :ordered ? "$(i+1). " : "- "
+    bullet(i) = list.type === :ordered ? "$(i). " : "- "
     # `iob` is reset at `take!` and then reused in the next loop
     iob = IOBuffer()
     # Loop through all items of the list
     for (i, item) in enumerate(node.children)
         render(iob, mime, item, item.children, page, doc; prenewline = false, kwargs...)
         eachline = split(String(take!(iob)), '\n')
-        eachline[2:end] .= "  " .* eachline[2:end]
+        eachline[2:end] .= "    " .* eachline[2:end]
         final_string = join(eachline, '\n')
         if !endswith(final_string, '\n')
             final_string = final_string * "\n"


### PR DESCRIPTION
Hi guys,

The recent update to the rendering of markdown lists (#276) caused the numbers to be incorrect. I fixed the numbering here, which was just a small miscount.

I also noticed that nested ordered lists were not working as intended. I managed to partially fix that. If the ordered list are indented with four spaces, the nesting should work now. If ordered list are only indented with two spaces, they still don't. List without numbers are correctly nested either way.

Let me know what you think.